### PR TITLE
chore: have mypy import stub libraries by default

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,4 +51,4 @@ jobs:
           isort --check .
 
       - name: Run type-check
-        run: mypy .
+        run: mypy --install-types --non-interactive .

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+python_version = 3.11

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,5 @@
 [mypy]
 python_version = 3.11
+
+[mypy-synthtool]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,0 @@
-[mypy]
-python_version = 3.8
-
-[mypy-synthtool]
-ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.11
+python_version = 3.8
 
 [mypy-synthtool]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ build-backend = "setuptools.build_meta"
 profile = "black"
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.8"
 warn_unused_configs = true
 exclude = [
     "owlbot.py"


### PR DESCRIPTION
Most libraries have stub packages for types. Adding `--install-types` will have mypy install them by default and not require them to be added to any deps.

Alternative is to add a poetry group for `typing` and add all required stubs to it: https://github.com/langchain-ai/langchain/blob/master/libs/core/pyproject.toml#L32