### PR TITLE
fix: backtick `table_name` to allow all characters for MySQLChatMessageHistory

### DIFF
--- a/tests/integration/test_mysql_chat_message_history.py
+++ b/tests/integration/test_mysql_chat_message_history.py
@@ -56,3 +56,23 @@ def test_chat_message_history(memory_engine: MySQLEngine) -> None:
     # verify clear() clears message history
     history.clear()
     assert len(history.messages) == 0
+
+
+def test_chat_message_history_custom_table_name(memory_engine: MySQLEngine) -> None:
+    """Test MySQLChatMessageHistory with custom table name"""
+    history = MySQLChatMessageHistory(
+        engine=memory_engine, session_id="test", table_name="message-store"
+    )
+    history.add_user_message("hi!")
+    history.add_ai_message("whats up?")
+    messages = history.messages
+
+    # verify messages are correct
+    assert messages[0].content == "hi!"
+    assert type(messages[0]) is HumanMessage
+    assert messages[1].content == "whats up?"
+    assert type(messages[1]) is AIMessage
+
+    # verify clear() clears message history
+    history.clear()
+    assert len(history.messages) == 0


### PR DESCRIPTION
Adding backticks around custom table name for `MySQLChatMessageHistory`, this allows for table names with SQL special characters such as a hyphen, (ie. `table_name="my-table"`)
