### PR TITLE
feat: Add document saver class and support save/load/delete user journey

### DIFF
--- a/src/langchain_google_cloud_sql_mysql/__init__.py
+++ b/src/langchain_google_cloud_sql_mysql/__init__.py
@@ -16,6 +16,14 @@ from langchain_google_cloud_sql_mysql.mysql_chat_message_history import (
     MySQLChatMessageHistory,
 )
 from langchain_google_cloud_sql_mysql.mysql_engine import MySQLEngine
-from langchain_google_cloud_sql_mysql.mysql_loader import MySQLLoader
+from langchain_google_cloud_sql_mysql.mysql_loader import (
+    MySQLDocumentSaver,
+    MySQLLoader,
+)
 
-__all__ = ["MySQLChatMessageHistory", "MySQLEngine", "MySQLLoader"]
+__all__ = [
+    "MySQLChatMessageHistory",
+    "MySQLDocumentSaver",
+    "MySQLEngine",
+    "MySQLLoader",
+]

--- a/src/langchain_google_cloud_sql_mysql/mysql_engine.py
+++ b/src/langchain_google_cloud_sql_mysql/mysql_engine.py
@@ -236,9 +236,9 @@ class MySQLEngine:
                     nullable=True,
                 )
             )
-        metadata = sqlalchemy.MetaData()
-        sqlalchemy.Table(table_name, metadata, *columns)
-        metadata.create_all(self.engine)
+        sqlalchemy.Table(table_name, sqlalchemy.MetaData(), *columns).create(
+            self.engine
+        )
 
     def _load_document_table(self, table_name: str) -> sqlalchemy.Table:
         """

--- a/src/langchain_google_cloud_sql_mysql/mysql_loader.py
+++ b/src/langchain_google_cloud_sql_mysql/mysql_loader.py
@@ -124,7 +124,13 @@ class MySQLLoader(BaseLoader):
             stmt = sqlalchemy.text(f"select * from `{self.table_name}`;")
         with self.engine.connect() as connection:
             result_proxy = connection.execute(stmt)
-            # Get field type information
+            # Get field type information.
+            # cursor.description is a sequence of 7-item sequences.
+            # Each of these sequences contains information describing one result column:
+            # - name, type_code, display_size, internal_size, precision, scale, null_ok
+            # The first two items (name and type_code) are mandatory, the other five are optional
+            # and are set to None if no meaningful values can be provided.
+            # link: https://peps.python.org/pep-0249/#description
             column_types = [
                 cast(tuple, field)[0:2] for field in result_proxy.cursor.description
             ]

--- a/src/langchain_google_cloud_sql_mysql/mysql_loader.py
+++ b/src/langchain_google_cloud_sql_mysql/mysql_loader.py
@@ -13,42 +13,48 @@
 # limitations under the License.
 import json
 from collections.abc import Iterable
-from typing import Any, Dict, List, Optional, Sequence, cast
+from typing import Any, Dict, Iterator, List, Optional, Sequence, cast
 
+import pymysql
 import sqlalchemy
 from langchain_community.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
 
 from langchain_google_cloud_sql_mysql.mysql_engine import MySQLEngine
 
+DEFAULT_CONTENT_COL = "page_content"
 DEFAULT_METADATA_COL = "langchain_metadata"
 
 
-def _parse_doc_from_table(
-    content_columns: Iterable[str],
-    metadata_columns: Iterable[str],
-    column_names: Iterable[str],
-    rows: Sequence[Any],
-) -> List[Document]:
-    docs = []
-    for row in rows:
-        page_content = " ".join(
-            str(getattr(row, column))
-            for column in content_columns
-            if column in column_names
-        )
-        metadata = {
-            column: getattr(row, column)
-            for column in metadata_columns
-            if column in column_names
-        }
-        if DEFAULT_METADATA_COL in metadata:
-            extra_metadata = json.loads(metadata[DEFAULT_METADATA_COL])
-            del metadata[DEFAULT_METADATA_COL]
-            metadata |= extra_metadata
-        doc = Document(page_content=page_content, metadata=metadata)
-        docs.append(doc)
-    return docs
+def _parse_doc_from_row(
+    content_columns: Iterable[str], metadata_columns: Iterable[str], row: Dict
+) -> Document:
+    page_content = " ".join(
+        str(row[column]) for column in content_columns if column in row
+    )
+    metadata: Dict[str, Any] = {}
+    # unnest metadata from langchain_metadata column
+    if DEFAULT_METADATA_COL in metadata_columns and row.get(DEFAULT_METADATA_COL):
+        for k, v in row[DEFAULT_METADATA_COL].items():
+            metadata[k] = v
+    # load metadata from other columns
+    for column in metadata_columns:
+        if column in row and column != DEFAULT_METADATA_COL:
+            metadata[column] = row[column]
+    return Document(page_content=page_content, metadata=metadata)
+
+
+def _parse_row_from_doc(column_names: Iterable[str], doc: Document) -> Dict:
+    doc_metadata = doc.metadata.copy()
+    row: Dict[str, Any] = {"page_content": doc.page_content}
+    for entry in doc.metadata:
+        if entry in column_names:
+            row[entry] = doc_metadata[entry]
+            del doc_metadata[entry]
+    # store extra metadata in langchain_metadata column in json format
+    if DEFAULT_METADATA_COL in column_names and len(doc_metadata) > 0:
+        row[DEFAULT_METADATA_COL] = doc_metadata
+    return row
 
 
 class MySQLLoader(BaseLoader):
@@ -57,29 +63,13 @@ class MySQLLoader(BaseLoader):
     def __init__(
         self,
         engine: MySQLEngine,
-        query: str,
+        table_name: str = "",
+        query: str = "",
         content_columns: Optional[List[str]] = None,
         metadata_columns: Optional[List[str]] = None,
     ):
         """
-        Args:
-          engine (MySQLEngine): MySQLEngine object to connect to the MySQL database.
-          query (str): The query to execute in MySQL format.
-          content_columns (List[str]): The columns to write into the `page_content`
-             of the document. Optional.
-          metadata_columns (List[str]): The columns to write into the `metadata` of the document.
-             Optional.
-        """
-        self.engine = engine
-        self.query = query
-        self.content_columns = content_columns
-        self.metadata_columns = metadata_columns
-
-    def load(self) -> List[Document]:
-        """
-        Load langchain documents from a Cloud SQL MySQL database.
-
-        Document page content defaults to the first columns present in the query or table and
+        Document page content defaults to the first column present in the query or table and
         metadata defaults to all other columns. Use with content_columns to overwrite the column
         used for page content. Use metadata_columns to select specific metadata columns rather
         than using all remaining columns.
@@ -87,21 +77,153 @@ class MySQLLoader(BaseLoader):
         If multiple content columns are specified, page_content’s string format will default to
         space-separated string concatenation.
 
+        Args:
+          engine (MySQLEngine): MySQLEngine object to connect to the MySQL database.
+          table_name (str): The MySQL database table name. (OneOf: table_name, query).
+          query (str): The query to execute in MySQL format.  (OneOf: table_name, query).
+          content_columns (List[str]): The columns to write into the `page_content`
+             of the document. Optional.
+          metadata_columns (List[str]): The columns to write into the `metadata` of the document.
+             Optional.
+        """
+        self.engine = engine
+        self.table_name = table_name
+        self.query = query
+        self.content_columns = content_columns
+        self.metadata_columns = metadata_columns
+        if not self.table_name and not self.query:
+            raise ValueError("One of 'table_name' or 'query' must be specified.")
+        if self.table_name and self.query:
+            raise ValueError(
+                "Cannot specify both 'table_name' and 'query'. Specify 'table_name' to load "
+                "entire table or 'query' to load a specific query."
+            )
+
+    def load(self) -> List[Document]:
+        """
+        Load langchain documents from a Cloud SQL MySQL database.
+
         Returns:
             (List[langchain_core.documents.Document]): a list of Documents with metadata from
                 specific columns.
         """
+        return list(self.lazy_load())
+
+    def lazy_load(self) -> Iterator[Document]:
+        """
+        Lazy Load langchain documents from a Cloud SQL MySQL database. Use lazy load to avoid
+        cache all documents in memory at once.
+
+        Returns:
+            (Iterator[langchain_core.documents.Document]): a list of Documents with metadata from
+                specific columns.
+        """
+        if self.query:
+            stmt = sqlalchemy.text(self.query)
+        else:
+            stmt = sqlalchemy.text(f"select * from `{self.table_name}`;")
         with self.engine.connect() as connection:
-            result_proxy = connection.execute(sqlalchemy.text(self.query))
+            result_proxy = connection.execute(stmt)
+            # Get field type information
+            column_types = [
+                cast(tuple, field)[0:2] for field in result_proxy.cursor.description
+            ]
             column_names = list(result_proxy.keys())
-            results = result_proxy.fetchall()
             content_columns = self.content_columns or [column_names[0]]
             metadata_columns = self.metadata_columns or [
                 col for col in column_names if col not in content_columns
             ]
-            return _parse_doc_from_table(
-                content_columns,
-                metadata_columns,
-                column_names,
-                results,
-            )
+            while True:
+                row = result_proxy.fetchone()
+                if not row:
+                    break
+                # Handle JSON fields
+                row_data = {}
+                for column, field_type in column_types:
+                    value = getattr(row, column)
+                    if field_type == pymysql.constants.FIELD_TYPE.JSON:
+                        row_data[column] = json.loads(value)
+                    else:
+                        row_data[column] = value
+                yield _parse_doc_from_row(content_columns, metadata_columns, row_data)
+
+
+class MySQLDocumentSaver:
+    """A class for saving langchain documents into a Cloud SQL MySQL database table."""
+
+    def __init__(
+        self,
+        engine: MySQLEngine,
+        table_name: str,
+    ):
+        """
+        MySQLDocumentSaver allows for saving of langchain documents in dataabase. If the table
+        doesn't exists, a table with default schema will be created. The default schema:
+            - page_content (type: text)
+            - langchain_metadata (type: JSON)
+
+        Args:
+          engine: MySQLEngine object to connect to the MySQL database.
+          table_name: The name of table for saving documents.
+        """
+        self.engine = engine
+        self.table_name = table_name
+        self._table: sqlalchemy.Table
+        self._create_table_if_not_exists()
+
+    def _create_table_if_not_exists(self) -> None:
+        create_table_query = f"""
+            CREATE TABLE IF NOT EXISTS `{self.table_name}` (
+                page_content TEXT NOT NULL,
+                {DEFAULT_METADATA_COL} JSON
+            );
+        """
+        with self.engine.connect() as conn:
+            conn.execute(sqlalchemy.text(create_table_query))
+            conn.commit()
+
+        self._table = self.engine._load_document_table(self.table_name)
+
+    def add_documents(self, docs: List[Document]) -> None:
+        """
+        Save documents in the DocumentSaver table. Document’s metadata is added to columns if found or
+        stored in langchain_metadata JSON column.
+
+        Args:
+            docs (List[langchain_core.documents.Document]): a list of documents to be saved.
+        """
+        with self.engine.connect() as conn:
+            for doc in docs:
+                row = _parse_row_from_doc(self._table.columns.keys(), doc)
+                conn.execute(sqlalchemy.insert(self._table).values(row))
+            conn.commit()
+
+    def delete(self, docs: List[Document]) -> None:
+        """
+        Delete all instances of a document from the DocumentSaver table by matching the entire Document
+        object.
+
+        Args:
+            docs (List[langchain_core.documents.Document]): a list of documents to be deleted.
+        """
+        with self.engine.connect() as conn:
+            for doc in docs:
+                row = _parse_row_from_doc(self._table.columns.keys(), doc)
+                # delete by matching all fields of document
+                where_conditions = []
+                for col in self._table.columns:
+                    if str(col.type) == "JSON":
+                        where_conditions.append(
+                            sqlalchemy.func.json_contains(
+                                col,
+                                json.dumps(row[col.name]),
+                            )
+                        )
+                    else:
+                        where_conditions.append(col == row[col.name])
+                conn.execute(
+                    sqlalchemy.delete(self._table).where(
+                        sqlalchemy.and_(*where_conditions)
+                    )
+                )
+            conn.commit()

--- a/tests/integration/test_mysql_loader.py
+++ b/tests/integration/test_mysql_loader.py
@@ -17,9 +17,14 @@ from typing import Generator
 
 import pytest
 import sqlalchemy
+from langchain.text_splitter import CharacterTextSplitter
 from langchain_core.documents import Document
 
-from langchain_google_cloud_sql_mysql import MySQLEngine, MySQLLoader
+from langchain_google_cloud_sql_mysql import (
+    MySQLDocumentSaver,
+    MySQLEngine,
+    MySQLLoader,
+)
 
 project_id = os.environ["PROJECT_ID"]
 region = os.environ["REGION"]
@@ -219,7 +224,7 @@ def test_load_from_query_with_langchain_metadata(engine):
                 CREATE TABLE IF NOT EXISTS `{table_name}`(
                     fruit_id INT AUTO_INCREMENT PRIMARY KEY,
                     fruit_name VARCHAR(100) NOT NULL,
-                    variety VARCHAR(50),  
+                    variety VARCHAR(50),
                     quantity_in_stock INT NOT NULL,
                     price_per_unit DECIMAL(6,2) NOT NULL,
                     langchain_metadata JSON NOT NULL
@@ -258,3 +263,262 @@ def test_load_from_query_with_langchain_metadata(engine):
             },
         )
     ]
+
+
+def test_save_doc_with_default_metadata(engine):
+    test_docs = [
+        Document(
+            page_content="Apple Granny Smith 150 0.99 1",
+            metadata={"fruit_id": 1},
+        ),
+        Document(
+            page_content="Banana Cavendish 200 0.59 0",
+            metadata={"fruit_id": 2},
+        ),
+        Document(
+            page_content="Orange Navel 80 1.29 1",
+            metadata={"fruit_id": 3},
+        ),
+    ]
+    saver = MySQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MySQLLoader(engine=engine, table_name=table_name)
+
+    saver.add_documents(test_docs)
+    docs = loader.load()
+
+    assert docs == test_docs
+    assert engine._load_document_table(table_name).columns.keys() == [
+        "page_content",
+        "langchain_metadata",
+    ]
+
+
+@pytest.mark.parametrize("store_metadata", [True, False])
+def test_save_doc_with_customized_metadata(engine, store_metadata):
+    engine.init_document_table(
+        table_name,
+        metadata_columns=[
+            sqlalchemy.Column(
+                "fruit_name",
+                sqlalchemy.UnicodeText,
+                primary_key=False,
+                nullable=True,
+            ),
+            sqlalchemy.Column(
+                "organic",
+                sqlalchemy.Boolean,
+                primary_key=False,
+                nullable=True,
+            ),
+        ],
+        store_metadata=store_metadata,
+    )
+    test_docs = [
+        Document(
+            page_content="Granny Smith 150 0.99",
+            metadata={"fruit_id": 1, "fruit_name": "Apple", "organic": 1},
+        ),
+    ]
+    saver = MySQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MySQLLoader(
+        engine=engine,
+        table_name=table_name,
+        metadata_columns=[
+            "fruit_id",
+            "fruit_name",
+            "organic",
+        ],
+    )
+
+    saver.add_documents(test_docs)
+    docs = loader.load()
+
+    if store_metadata:
+        docs == test_docs
+        assert engine._load_document_table(table_name).columns.keys() == [
+            "page_content",
+            "fruit_name",
+            "organic",
+            "langchain_metadata",
+        ]
+    else:
+        assert docs == [
+            Document(
+                page_content="Granny Smith 150 0.99",
+                metadata={"fruit_name": "Apple", "organic": 1},
+            ),
+        ]
+        assert engine._load_document_table(table_name).columns.keys() == [
+            "page_content",
+            "fruit_name",
+            "organic",
+        ]
+
+
+def test_save_doc_without_metadata(engine):
+    engine.init_document_table(
+        table_name,
+        store_metadata=False,
+    )
+    test_docs = [
+        Document(
+            page_content="Granny Smith 150 0.99",
+            metadata={"fruit_id": 1, "fruit_name": "Apple", "organic": 1},
+        ),
+    ]
+    saver = MySQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MySQLLoader(
+        engine=engine,
+        table_name=table_name,
+    )
+
+    saver.add_documents(test_docs)
+    docs = loader.load()
+
+    assert docs == [
+        Document(
+            page_content="Granny Smith 150 0.99",
+            metadata={},
+        ),
+    ]
+    assert engine._load_document_table(table_name).columns.keys() == [
+        "page_content",
+    ]
+
+
+def test_delete_doc_with_default_metadata(engine):
+    test_docs = [
+        Document(
+            page_content="Apple Granny Smith 150 0.99 1",
+            metadata={"fruit_id": 1},
+        ),
+        Document(
+            page_content="Banana Cavendish 200 0.59 0 1",
+            metadata={"fruit_id": 2},
+        ),
+    ]
+    saver = MySQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MySQLLoader(engine=engine, table_name=table_name)
+
+    saver.add_documents(test_docs)
+    docs = loader.load()
+    assert docs == test_docs
+
+    saver.delete(docs[:1])
+    assert len(loader.load()) == 1
+
+    saver.delete(docs)
+    assert len(loader.load()) == 0
+
+
+@pytest.mark.parametrize("store_metadata", [True, False])
+def test_delete_doc_with_customized_metadata(engine, store_metadata):
+    engine.init_document_table(
+        table_name,
+        metadata_columns=[
+            sqlalchemy.Column(
+                "fruit_name",
+                sqlalchemy.UnicodeText,
+                primary_key=False,
+                nullable=True,
+            ),
+            sqlalchemy.Column(
+                "organic",
+                sqlalchemy.Boolean,
+                primary_key=False,
+                nullable=True,
+            ),
+        ],
+        store_metadata=store_metadata,
+    )
+    test_docs = [
+        Document(
+            page_content="Granny Smith 150 0.99",
+            metadata={"fruit-id": 1, "fruit_name": "Apple", "organic": 1},
+        ),
+        Document(
+            page_content="Cavendish 200 0.59 0",
+            metadata={"fruit_id": 2, "fruit_name": "Banana", "organic": 1},
+        ),
+    ]
+    saver = MySQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MySQLLoader(engine=engine, table_name=table_name)
+
+    saver.add_documents(test_docs)
+    docs = loader.load()
+    assert len(docs) == 2
+
+    saver.delete(docs[:1])
+    assert len(loader.load()) == 1
+
+    saver.delete(docs)
+    assert len(loader.load()) == 0
+
+
+def test_delete_doc_with_query(engine):
+    engine.init_document_table(
+        table_name,
+        metadata_columns=[
+            sqlalchemy.Column(
+                "fruit_name",
+                sqlalchemy.UnicodeText,
+                primary_key=False,
+                nullable=True,
+            ),
+            sqlalchemy.Column(
+                "organic",
+                sqlalchemy.Boolean,
+                primary_key=False,
+                nullable=True,
+            ),
+        ],
+        store_metadata=True,
+    )
+    test_docs = [
+        Document(
+            page_content="Granny Smith 150 0.99",
+            metadata={"fruit-id": 1, "fruit_name": "Apple", "organic": 1},
+        ),
+        Document(
+            page_content="Cavendish 200 0.59 0",
+            metadata={"fruit_id": 2, "fruit_name": "Banana", "organic": 0},
+        ),
+        Document(
+            page_content="Navel 80 1.29 1",
+            metadata={"fruit_id": 3, "fruit_name": "Orange", "organic": 1},
+        ),
+    ]
+    saver = MySQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MySQLLoader(engine=engine, table_name=table_name)
+    query = f"select * from `{table_name}` where fruit_name='Apple';"
+    query_loader = MySQLLoader(engine=engine, query=query)
+
+    saver.add_documents(test_docs)
+    docs = query_loader.load()
+    assert len(docs) == 1
+
+    saver.delete(docs)
+    assert len(loader.load()) == 2
+
+
+def test_load_and_spilt(engine):
+    text_splitter = CharacterTextSplitter(
+        separator=" ",
+        chunk_size=10,
+        chunk_overlap=2,
+        length_function=len,
+        is_separator_regex=False,
+    )
+    test_docs = [
+        Document(
+            page_content="Apple Granny Smith 150 0.99 1",
+            metadata={"fruit_id": 1},
+        ),
+    ]
+    saver = MySQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MySQLLoader(engine=engine, table_name=table_name)
+
+    saver.add_documents(test_docs)
+    docs = loader.load_and_split(text_splitter=text_splitter)
+
+    assert len(docs) == 4

--- a/tests/integration/test_mysql_loader.py
+++ b/tests/integration/test_mysql_loader.py
@@ -266,6 +266,7 @@ def test_load_from_query_with_langchain_metadata(engine):
 
 
 def test_save_doc_with_default_metadata(engine):
+    engine.init_document_table(table_name)
     test_docs = [
         Document(
             page_content="Apple Granny Smith 150 0.99 1",
@@ -387,6 +388,7 @@ def test_save_doc_without_metadata(engine):
 
 
 def test_delete_doc_with_default_metadata(engine):
+    engine.init_document_table(table_name)
     test_docs = [
         Document(
             page_content="Apple Granny Smith 150 0.99 1",
@@ -502,6 +504,7 @@ def test_delete_doc_with_query(engine):
 
 
 def test_load_and_spilt(engine):
+    engine.init_document_table(table_name)
     text_splitter = CharacterTextSplitter(
         separator=" ",
         chunk_size=10,

--- a/tests/unit/test_doc2row.py
+++ b/tests/unit/test_doc2row.py
@@ -46,32 +46,28 @@ row_customized_nested = {
 
 
 def test_row2doc_default():
-    assert (
-        _parse_doc_from_row([DEFAULT_CONTENT_COL], [DEFAULT_METADATA_COL], row_default)
-        == test_doc
+    doc = _parse_doc_from_row(
+        [DEFAULT_CONTENT_COL], [DEFAULT_METADATA_COL], row_default
     )
+    assert doc == test_doc
 
 
 def test_row2doc_customized():
-    assert (
-        _parse_doc_from_row(
-            ["variety", "quantity_in_stock", "price_per_unit"],
-            ["fruit-id", "fruit_name", "organic"],
-            row_customized_flat,
-        )
-        == test_doc
+    doc = _parse_doc_from_row(
+        ["variety", "quantity_in_stock", "price_per_unit"],
+        ["fruit-id", "fruit_name", "organic"],
+        row_customized_flat,
     )
+    assert doc == test_doc
 
 
 def test_row2doc_unnest_default_metadata():
-    assert (
-        _parse_doc_from_row(
-            ["variety", "quantity_in_stock", "price_per_unit"],
-            ["langchain_metadata"],
-            row_customized_nested,
-        )
-        == test_doc
+    doc = _parse_doc_from_row(
+        ["variety", "quantity_in_stock", "price_per_unit"],
+        ["langchain_metadata"],
+        row_customized_nested,
     )
+    assert doc == test_doc
 
 
 def test_row2doc_ovrride_default_metadata():

--- a/tests/unit/test_doc2row.py
+++ b/tests/unit/test_doc2row.py
@@ -1,0 +1,145 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from langchain_core.documents import Document
+
+from langchain_google_cloud_sql_mysql.mysql_loader import (
+    DEFAULT_CONTENT_COL,
+    DEFAULT_METADATA_COL,
+    _parse_doc_from_row,
+    _parse_row_from_doc,
+)
+
+test_doc = Document(
+    page_content="Granny Smith 150 0.99",
+    metadata={"fruit-id": 1, "fruit_name": "Apple", "organic": 1},
+)
+cols_default = [DEFAULT_CONTENT_COL, DEFAULT_METADATA_COL]
+row_default = {
+    "page_content": "Granny Smith 150 0.99",
+    "langchain_metadata": {"fruit-id": 1, "fruit_name": "Apple", "organic": 1},
+}
+row_customized_flat = {
+    "fruit-id": 1,
+    "fruit_name": "Apple",
+    "variety": "Granny Smith",
+    "quantity_in_stock": 150,
+    "price_per_unit": 0.99,
+    "organic": 1,
+}
+row_customized_nested = {
+    "variety": "Granny Smith",
+    "quantity_in_stock": 150,
+    "price_per_unit": 0.99,
+    "langchain_metadata": {"fruit-id": 1, "fruit_name": "Apple", "organic": 1},
+}
+
+
+def test_row2doc_default():
+    assert (
+        _parse_doc_from_row([DEFAULT_CONTENT_COL], [DEFAULT_METADATA_COL], row_default)
+        == test_doc
+    )
+
+
+def test_row2doc_customized():
+    assert (
+        _parse_doc_from_row(
+            ["variety", "quantity_in_stock", "price_per_unit"],
+            ["fruit-id", "fruit_name", "organic"],
+            row_customized_flat,
+        )
+        == test_doc
+    )
+
+
+def test_row2doc_unnest_default_metadata():
+    assert (
+        _parse_doc_from_row(
+            ["variety", "quantity_in_stock", "price_per_unit"],
+            ["langchain_metadata"],
+            row_customized_nested,
+        )
+        == test_doc
+    )
+
+
+def test_row2doc_ovrride_default_metadata():
+    row_override = row_customized_nested.copy()
+    row_override["fruit_name"] = "Banana"
+    assert _parse_doc_from_row(
+        ["quantity_in_stock", "price_per_unit"],
+        ["fruit_name", "variety", "langchain_metadata"],
+        row_override,
+    ) == Document(
+        page_content="150 0.99",
+        metadata={
+            "fruit-id": 1,
+            "variety": "Granny Smith",
+            "fruit_name": "Banana",
+            "organic": 1,
+        },
+    )
+
+
+def test_row2doc_metadata_col_nonexist():
+    assert _parse_doc_from_row(
+        ["variety", "quantity_in_stock", "price_per_unit"],
+        ["fruit-id"],
+        row_customized_nested,
+    ) == Document(page_content="Granny Smith 150 0.99")
+
+
+def test_doc2row_default():
+    assert _parse_row_from_doc(cols_default, test_doc) == row_default
+
+
+def test_doc2row_customized():
+    assert _parse_row_from_doc([DEFAULT_CONTENT_COL, "fruit-id"], test_doc) == {
+        "fruit-id": 1,
+        "page_content": "Granny Smith 150 0.99",
+    }
+
+
+def test_doc2row_no_metadata():
+    assert _parse_row_from_doc([DEFAULT_CONTENT_COL], test_doc) == {
+        "page_content": "Granny Smith 150 0.99",
+    }
+
+
+def test_doc2row_store_extra_metadata():
+    assert _parse_row_from_doc(
+        [DEFAULT_CONTENT_COL, "fruit-id", DEFAULT_METADATA_COL], test_doc
+    ) == {
+        "fruit-id": 1,
+        "page_content": "Granny Smith 150 0.99",
+        "langchain_metadata": {
+            "fruit_name": "Apple",
+            "organic": 1,
+        },
+    }
+
+
+def test_doc2row2doc_customized_metadata():
+    customized_metadatas = [
+        [],
+        ["fruit-id"],
+        ["fruit-id", "fruit_name", "organic"],
+        ["fruit-id", "fruit_name", "organic", "other"],
+    ]
+    for metadata in customized_metadatas:
+        assert test_doc == _parse_doc_from_row(
+            [DEFAULT_CONTENT_COL],
+            metadata + [DEFAULT_METADATA_COL],
+            _parse_row_from_doc(metadata + [DEFAULT_METADATA_COL], test_doc),
+        )


### PR DESCRIPTION
Add document saver class and support save/load/delete user journeys.

In detail:

- Load documents via default table
- Load documents via custom table/metadata
- Load documents via custom page content columns
- Load documents via custom metadata columns
- Initialize MySQLDocumentSaver with existing table
- Initialize custom MySQLDocumentSaver table & add documents with metadata
- Delete documents