### PR TITLE
feat: support saving with customized content column and saving/loading with non-default metadata JSON column.

### DIFF
--- a/src/langchain_google_cloud_sql_mysql/mysql_engine.py
+++ b/src/langchain_google_cloud_sql_mysql/mysql_engine.py
@@ -235,6 +235,7 @@ class MySQLEngine:
         metadata_columns: List[sqlalchemy.Column] = [],
         content_column: str = "page_content",
         metadata_json_column: Optional[str] = "langchain_metadata",
+        overwrite_existing: bool = False,
     ) -> None:
         """
         Create a table for saving of langchain documents.
@@ -245,9 +246,14 @@ class MySQLEngine:
                 to create for custom metadata. Optional.
             content_column (str): The column to store document content.
                 Deafult: `page_content`.
-            metadata_json_column (str): The column to store extra metadata in JSON format.
+            metadata_json_column (Optional[str]): The column to store extra metadata in JSON format.
                 Default: `langchain_metadata`. Optional.
+            overwrite_existing (bool): Whether to drop existing table. Default: False.
         """
+        if overwrite_existing:
+            with self.engine.connect() as conn:
+                conn.execute(sqlalchemy.text(f"DROP TABLE IF EXISTS `{table_name}`;"))
+
         columns = [
             sqlalchemy.Column(
                 content_column,

--- a/src/langchain_google_cloud_sql_mysql/mysql_engine.py
+++ b/src/langchain_google_cloud_sql_mysql/mysql_engine.py
@@ -233,7 +233,8 @@ class MySQLEngine:
         self,
         table_name: str,
         metadata_columns: List[sqlalchemy.Column] = [],
-        store_metadata: bool = True,
+        content_json_column: str = "page_content",
+        metadata_json_column: Optional[str] = "langchain_metadata",
     ) -> None:
         """
         Create a table for saving of langchain documents.
@@ -242,22 +243,24 @@ class MySQLEngine:
             table_name (str): The MySQL database table name.
             metadata_columns (List[sqlalchemy.Column]): A list of SQLAlchemy Columns
                 to create for custom metadata. Optional.
-            store_metadata (bool): Whether to store extra metadata in a metadata column
-                if not described in 'metadata' field list (Default: True).
+            content_column (str): The column to store document content.
+                Deafult: `page_content`.
+            metadata_json_column (str): The column to store extra metadata in JSON format.
+                Default: `langchain_metadata`. Optional.
         """
         columns = [
             sqlalchemy.Column(
-                "page_content",
+                content_json_column,
                 sqlalchemy.UnicodeText,
                 primary_key=False,
                 nullable=False,
             )
         ]
         columns += metadata_columns
-        if store_metadata:
+        if metadata_json_column:
             columns.append(
                 sqlalchemy.Column(
-                    "langchain_metadata",
+                    metadata_json_column,
                     sqlalchemy.JSON,
                     primary_key=False,
                     nullable=True,

--- a/src/langchain_google_cloud_sql_mysql/mysql_engine.py
+++ b/src/langchain_google_cloud_sql_mysql/mysql_engine.py
@@ -233,7 +233,7 @@ class MySQLEngine:
         self,
         table_name: str,
         metadata_columns: List[sqlalchemy.Column] = [],
-        content_json_column: str = "page_content",
+        content_column: str = "page_content",
         metadata_json_column: Optional[str] = "langchain_metadata",
     ) -> None:
         """
@@ -250,7 +250,7 @@ class MySQLEngine:
         """
         columns = [
             sqlalchemy.Column(
-                content_json_column,
+                content_column,
                 sqlalchemy.UnicodeText,
                 primary_key=False,
                 nullable=False,

--- a/tests/integration/test_mysql_loader.py
+++ b/tests/integration/test_mysql_loader.py
@@ -314,6 +314,7 @@ def test_save_doc_with_customized_metadata(engine, metadata_json_column):
         ],
         content_column=content_column,
         metadata_json_column=metadata_json_column,
+        overwrite_existing=True,
     )
     test_docs = [
         Document(
@@ -442,6 +443,7 @@ def test_delete_doc_with_customized_metadata(engine, metadata_json_column):
         ],
         content_column=content_column,
         metadata_json_column=metadata_json_column,
+        overwrite_existing=True,
     )
     test_docs = [
         Document(

--- a/tests/integration/test_mysql_loader.py
+++ b/tests/integration/test_mysql_loader.py
@@ -294,11 +294,9 @@ def test_save_doc_with_default_metadata(engine):
     ]
 
 
-@pytest.mark.parametrize("content_column", [None, "content_col_test"])
 @pytest.mark.parametrize("metadata_json_column", [None, "metadata_col_test"])
-def test_save_doc_with_customized_metadata(
-    engine, content_column, metadata_json_column
-):
+def test_save_doc_with_customized_metadata(engine, metadata_json_column):
+    content_column = "content_col_test"
     engine.init_document_table(
         table_name,
         metadata_columns=[
@@ -333,12 +331,12 @@ def test_save_doc_with_customized_metadata(
     loader = MySQLLoader(
         engine=engine,
         table_name=table_name,
-        content_culumns=[content_column],
+        content_columns=[content_column],
         metadata_columns=[
-            "fruit_id",
             "fruit_name",
             "organic",
-        ],
+        ]
+        + ([metadata_json_column] if metadata_json_column else []),
         metadata_json_column=metadata_json_column,
     )
 
@@ -348,7 +346,7 @@ def test_save_doc_with_customized_metadata(
     if metadata_json_column:
         docs == test_docs
         assert engine._load_document_table(table_name).columns.keys() == [
-            content_column if content_column else "page_content",
+            content_column,
             "fruit_name",
             "organic",
             metadata_json_column,
@@ -361,7 +359,7 @@ def test_save_doc_with_customized_metadata(
             ),
         ]
         assert engine._load_document_table(table_name).columns.keys() == [
-            content_column if content_column else "page_content",
+            content_column,
             "fruit_name",
             "organic",
         ]
@@ -424,11 +422,9 @@ def test_delete_doc_with_default_metadata(engine):
     assert len(loader.load()) == 0
 
 
-@pytest.mark.parametrize("content_column", [None, "content_col_test"])
 @pytest.mark.parametrize("metadata_json_column", [None, "metadata_col_test"])
-def test_delete_doc_with_customized_metadata(
-    engine, content_column, metadata_json_column
-):
+def test_delete_doc_with_customized_metadata(engine, metadata_json_column):
+    content_column = "content_col_test"
     engine.init_document_table(
         table_name,
         metadata_columns=[
@@ -465,7 +461,10 @@ def test_delete_doc_with_customized_metadata(
         metadata_json_column=metadata_json_column,
     )
     loader = MySQLLoader(
-        engine=engine, table_name=table_name, metadata_json_column=metadata_json_column
+        engine=engine,
+        table_name=table_name,
+        content_columns=[content_column],
+        metadata_json_column=metadata_json_column,
     )
 
     saver.add_documents(test_docs)

--- a/tests/integration/test_mysql_loader.py
+++ b/tests/integration/test_mysql_loader.py
@@ -335,8 +335,7 @@ def test_save_doc_with_customized_metadata(engine, metadata_json_column):
         metadata_columns=[
             "fruit_name",
             "organic",
-        ]
-        + ([metadata_json_column] if metadata_json_column else []),
+        ],
         metadata_json_column=metadata_json_column,
     )
 

--- a/tests/integration/test_mysql_loader.py
+++ b/tests/integration/test_mysql_loader.py
@@ -249,7 +249,6 @@ def test_load_from_query_with_langchain_metadata(engine):
         query=query,
         metadata_columns=[
             "fruit_name",
-            "langchain_metadata",
         ],
     )
 

--- a/tests/unit/test_doc2row.py
+++ b/tests/unit/test_doc2row.py
@@ -89,11 +89,12 @@ def test_row2doc_ovrride_default_metadata():
 
 
 def test_row2doc_metadata_col_nonexist():
-    assert _parse_doc_from_row(
+    doc = _parse_doc_from_row(
         ["variety", "quantity_in_stock", "price_per_unit"],
         ["fruit-id"],
         row_customized_nested,
-    ) == Document(page_content="Granny Smith 150 0.99")
+    )
+    assert doc == test_doc
 
 
 def test_doc2row_default():

--- a/tests/unit/test_doc2row.py
+++ b/tests/unit/test_doc2row.py
@@ -93,8 +93,9 @@ def test_row2doc_metadata_col_nonexist():
         ["variety", "quantity_in_stock", "price_per_unit"],
         ["fruit-id"],
         row_customized_nested,
+        metadata_json_column="non-exist",
     )
-    assert doc == test_doc
+    assert doc == Document(page_content="Granny Smith 150 0.99")
 
 
 def test_doc2row_default():


### PR DESCRIPTION
User can now specify customized content column and metadata JSON column in replace of the default "page_content" and "langchain_metadata" column.

Summary of changes:
- MySQLEngine
  - init_document_table can create column with non-default name `content_column` and `metadata_json_column`, deprecate `store_metadata`.
- MySQLLoader
  - Add `metadata_json_column` for loading document.metadata from non-default JSON metadata field. 
  - raise ValueError if specified columns cannot be found in table.
- MySQLSaver
  - Add `content_column` for saving document.page_content into non-default content field.
  - Add `metadata_json_column` for saving document.metadata into non-default JSON metadata field.
  - Support deleting document with non-default content and JSON metadata field.
- test_mysql_loader.py
  - test_save_doc_with_customized_metadata will use non-default content and JSON metadata column.
  - test_delete_doc_with_customized_metadata will use non-default content and JSON metadata column.
