### PR TITLE
chore: add helper for creating chat message table

### DIFF
--- a/src/langchain_google_cloud_sql_mysql/mysql_engine.py
+++ b/src/langchain_google_cloud_sql_mysql/mysql_engine.py
@@ -202,6 +202,33 @@ class MySQLEngine:
         """
         return self.engine.connect()
 
+    def init_chat_history_table(self, table_name: str) -> None:
+        """Create table with schema required for MySQLChatMessageHistory class.
+
+        Required schema is as follows:
+
+            CREATE TABLE {table_name} (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data JSON NOT NULL,
+                type TEXT NOT NULL
+            )
+
+        Args:
+            table_name (str): Name of database table to create for storing chat
+                message history.
+        """
+        create_table_query = f"""CREATE TABLE IF NOT EXISTS `{table_name}` (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          session_id TEXT NOT NULL,
+          data JSON NOT NULL,
+          type TEXT NOT NULL
+        );"""
+
+        with self.engine.connect() as conn:
+            conn.execute(sqlalchemy.text(create_table_query))
+            conn.commit()
+
     def init_document_table(
         self,
         table_name: str,

--- a/tests/integration/test_mysql_chat_message_history.py
+++ b/tests/integration/test_mysql_chat_message_history.py
@@ -38,7 +38,7 @@ def setup() -> Generator:
     query = """CREATE TABLE malformed_table (
         id INT AUTO_INCREMENT PRIMARY KEY,
         session_id TEXT NOT NULL,
-        data JSON NOT NULL,
+        data JSON NOT NULL
     );"""
     with engine.connect() as conn:
         conn.execute(sqlalchemy.text(query))

--- a/tests/integration/test_mysql_chat_message_history.py
+++ b/tests/integration/test_mysql_chat_message_history.py
@@ -25,6 +25,7 @@ project_id = os.environ["PROJECT_ID"]
 region = os.environ["REGION"]
 instance_id = os.environ["INSTANCE_ID"]
 db_name = os.environ["DB_NAME"]
+table_name = "message_store"
 
 
 @pytest.fixture(name="memory_engine")
@@ -33,35 +34,27 @@ def setup() -> Generator:
         project_id=project_id, region=region, instance=instance_id, database=db_name
     )
 
+    # create table with malformed schema (missing 'type')
+    query = """CREATE TABLE malformed_table (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        data JSON NOT NULL,
+    );"""
+    with engine.connect() as conn:
+        conn.execute(sqlalchemy.text(query))
+        conn.commit()
     yield engine
     # use default table for MySQLChatMessageHistory
-    table_name = "message_store"
     with engine.connect() as conn:
         conn.execute(sqlalchemy.text(f"DROP TABLE IF EXISTS `{table_name}`"))
+        conn.execute(sqlalchemy.text(f"DROP TABLE IF EXISTS malformed_table"))
         conn.commit()
 
 
 def test_chat_message_history(memory_engine: MySQLEngine) -> None:
-    history = MySQLChatMessageHistory(engine=memory_engine, session_id="test")
-    history.add_user_message("hi!")
-    history.add_ai_message("whats up?")
-    messages = history.messages
-
-    # verify messages are correct
-    assert messages[0].content == "hi!"
-    assert type(messages[0]) is HumanMessage
-    assert messages[1].content == "whats up?"
-    assert type(messages[1]) is AIMessage
-
-    # verify clear() clears message history
-    history.clear()
-    assert len(history.messages) == 0
-
-
-def test_chat_message_history_custom_table_name(memory_engine: MySQLEngine) -> None:
-    """Test MySQLChatMessageHistory with custom table name"""
+    memory_engine.init_chat_history_table(table_name)
     history = MySQLChatMessageHistory(
-        engine=memory_engine, session_id="test", table_name="message-store"
+        engine=memory_engine, session_id="test", table_name=table_name
     )
     history.add_user_message("hi!")
     history.add_ai_message("whats up?")
@@ -76,3 +69,26 @@ def test_chat_message_history_custom_table_name(memory_engine: MySQLEngine) -> N
     # verify clear() clears message history
     history.clear()
     assert len(history.messages) == 0
+
+
+def test_chat_message_history_table_does_not_exist(memory_engine: MySQLEngine) -> None:
+    """Test that MySQLChatMessageHistory fails if table does not exist."""
+    with pytest.raises(AttributeError) as exc_info:
+        MySQLChatMessageHistory(
+            engine=memory_engine, session_id="test", table_name="missing_table"
+        )
+        # assert custom error message for missing table
+        assert (
+            exc_info.value.args[0]
+            == f"Table 'missing_table' does not exist. Please create it before initializing MySQLChatMessageHistory. See MySQLEngine.init_chat_history_table() for a helper method."
+        )
+
+
+def test_chat_message_history_table_malformed_schema(
+    memory_engine: MySQLEngine,
+) -> None:
+    """Test that MySQLChatMessageHistory fails if schema is malformed."""
+    with pytest.raises(IndexError):
+        MySQLChatMessageHistory(
+            engine=memory_engine, session_id="test", table_name="malformed_table"
+        )


### PR DESCRIPTION
Porting changes that came from the review discussion of MSSQL PR https://github.com/googleapis/langchain-google-cloud-sql-mssql-python/pull/9

Making `table_name` a required arg of `MySQLChatMessageHistory` and removing auto creation of table by moving it to helper method.
