### PR TITLE
feat: add MySQLVectorStore initialization methods

### DIFF
--- a/integration.cloudbuild.yaml
+++ b/integration.cloudbuild.yaml
@@ -43,7 +43,7 @@ availableSecrets:
       env: "DB_PASSWORD"
 
 substitutions:
-  _INSTANCE_ID: test-instance
+  _INSTANCE_ID: mysql-vector
   _REGION: us-central1
   _DB_NAME: test
   _VERSION: "3.8"

--- a/src/langchain_google_cloud_sql_mysql/__init__.py
+++ b/src/langchain_google_cloud_sql_mysql/__init__.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 from .chat_message_history import MySQLChatMessageHistory
-from .engine import MySQLEngine
+from .engine import Column, MySQLEngine
 from .loader import MySQLDocumentSaver, MySQLLoader
 from .vectorstore import MySQLVectorStore
 from .version import __version__
 
 __all__ = [
+    "Column",
     "MySQLChatMessageHistory",
     "MySQLDocumentSaver",
     "MySQLEngine",

--- a/src/langchain_google_cloud_sql_mysql/chat_message_history.py
+++ b/src/langchain_google_cloud_sql_mysql/chat_message_history.py
@@ -25,7 +25,7 @@ class MySQLChatMessageHistory(BaseChatMessageHistory):
     """Chat message history stored in a Cloud SQL MySQL database.
 
     Args:
-        engine (MySQLEngine): SQLAlchemy connection pool engine for managing
+        engine (MySQLEngine): Connection pool engine for managing
             connections to Cloud SQL for MySQL.
         session_id (str): Arbitrary key that is used to store the messages
             of a single chat session.

--- a/src/langchain_google_cloud_sql_mysql/engine.py
+++ b/src/langchain_google_cloud_sql_mysql/engine.py
@@ -352,6 +352,8 @@ class MySQLEngine:
             id_column (str):  Name of the column to store ids.
                 Default: `langchain_id`. Optional,
             overwrite_existing (bool): Whether to drop existing table. Default: False.
+            store_metadata (bool): Whether to store metadata in the table.
+                Default: True.
         """
         query = f"""CREATE TABLE `{table_name}`(
             `{id_column}` CHAR(36) PRIMARY KEY,

--- a/src/langchain_google_cloud_sql_mysql/indexes.py
+++ b/src/langchain_google_cloud_sql_mysql/indexes.py
@@ -12,17 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .chat_message_history import MySQLChatMessageHistory
-from .engine import MySQLEngine
-from .loader import MySQLDocumentSaver, MySQLLoader
-from .vectorstore import MySQLVectorStore
-from .version import __version__
+from abc import ABC
+from dataclasses import dataclass
 
-__all__ = [
-    "MySQLChatMessageHistory",
-    "MySQLDocumentSaver",
-    "MySQLEngine",
-    "MySQLLoader",
-    "MySQLVectorStore",
-    "__version__",
-]
+
+@dataclass
+class QueryOptions(ABC):
+    def to_string(self) -> str:
+        raise NotImplementedError("to_string method must be implemented by subclass")

--- a/src/langchain_google_cloud_sql_mysql/vectorstore.py
+++ b/src/langchain_google_cloud_sql_mysql/vectorstore.py
@@ -1,0 +1,257 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: Remove below import when minimum supported Python version is 3.10
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, List, Optional, Type
+
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+from langchain_core.vectorstores import VectorStore
+
+from .engine import MySQLEngine
+from .indexes import QueryOptions
+
+
+class MySQLVectorStore(VectorStore):
+    def __init__(
+        self,
+        engine: MySQLEngine,
+        embedding_service: Embeddings,
+        table_name: str,
+        content_column: str = "content",
+        embedding_column: str = "embedding",
+        metadata_columns: List[str] = [],
+        ignore_metadata_columns: Optional[List[str]] = None,
+        id_column: str = "langchain_id",
+        metadata_json_column: Optional[str] = "langchain_metadata",
+        index_query_options: Optional[QueryOptions] = None,
+    ):
+        """Constructor for MySQLVectorStore.
+        Args:
+            engine (MySQLEngine): Connection pool engine for managing
+                connections to Cloud SQL for MySQL database.
+            embedding_service (Embeddings): Text embedding model to use.
+            table_name (str): Name of an existing table or table to be created.
+            content_column (str): Column that represent a Document's
+                page_content. Defaults to "content".
+            embedding_column (str): Column for embedding vectors. The embedding
+                is generated from the document value. Defaults to "embedding".
+            metadata_columns (List[str]): Column(s) that represent a document's metadata.
+            ignore_metadata_columns (List[str]): Column(s) to ignore in
+                pre-existing tables for a document's metadata. Can not be used
+                with metadata_columns. Defaults to None.
+            id_column (str): Column that represents the Document's id.
+                Defaults to "langchain_id".
+            metadata_json_column (str): Column to store metadata as JSON.
+                Defaults to "langchain_metadata".
+        """
+        if metadata_columns and ignore_metadata_columns:
+            raise ValueError(
+                "Can not use both metadata_columns and ignore_metadata_columns."
+            )
+        # Get field type information
+        stmt = f"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '{table_name}'"
+
+        results = engine._fetch(stmt)
+        columns = {}
+        for field in results:
+            columns[field["COLUMN_NAME"]] = field["DATA_TYPE"]
+
+        # Check columns
+        if id_column not in columns:
+            raise ValueError(f"Id column, {id_column}, does not exist.")
+        if content_column not in columns:
+            raise ValueError(f"Content column, {content_column}, does not exist.")
+        content_type = columns[content_column]
+        if content_type != "text" and "char" not in content_type:
+            raise ValueError(
+                f"Content column, {content_column}, is type, {content_type}. It must be a type of character string."
+            )
+        if embedding_column not in columns:
+            raise ValueError(f"Embedding column, {embedding_column}, does not exist.")
+        if columns[embedding_column] != "varbinary":
+            raise ValueError(
+                f"Embedding column, {embedding_column}, is not type Vector (varbinary)."
+            )
+
+        metadata_json_column = (
+            None if metadata_json_column not in columns else metadata_json_column
+        )
+
+        # If using metadata_columns check to make sure column exists
+        for column in metadata_columns:
+            if column not in columns:
+                raise ValueError(f"Metadata column, {column}, does not exist.")
+
+        # If using ignore_metadata_columns, filter out known columns and set known metadata columns
+        all_columns = columns
+        if ignore_metadata_columns:
+            for column in ignore_metadata_columns:
+                del all_columns[column]
+
+            del all_columns[id_column]
+            del all_columns[content_column]
+            del all_columns[embedding_column]
+            metadata_columns = [key for key, _ in all_columns.keys()]
+
+        # set all class attributes
+        self.engine = engine
+        self.embedding_service = embedding_service
+        self.table_name = table_name
+        self.content_column = content_column
+        self.embedding_column = embedding_column
+        self.metadata_columns = metadata_columns
+        self.id_column = id_column
+        self.metadata_json_column = metadata_json_column
+        self.index_query_options = index_query_options
+
+    @property
+    def embeddings(self) -> Embeddings:
+        return self.embedding_service
+
+    def _add_embeddings(
+        self,
+        texts: Iterable[str],
+        embeddings: List[List[float]],
+        metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        if not ids:
+            ids = ["NULL" for _ in texts]
+        if not metadatas:
+            metadatas = [{} for _ in texts]
+        # Insert embeddings
+        for id, content, embedding, metadata in zip(ids, texts, embeddings, metadatas):
+            metadata_col_names = (
+                ", " + ", ".join(self.metadata_columns)
+                if len(self.metadata_columns) > 0
+                else ""
+            )
+            insert_stmt = f"INSERT INTO `{self.table_name}`(`{self.id_column}`, `{self.content_column}`, `{self.embedding_column}`{metadata_col_names}"
+            values = {"id": id, "content": content, "embedding": str(embedding)}
+            values_stmt = "VALUES (:id, :content, string_to_vector(:embedding)"
+
+            # Add metadata
+            extra = metadata
+            for metadata_column in self.metadata_columns:
+                if metadata_column in metadata:
+                    values_stmt += f", :{metadata_column}"
+                    values[metadata_column] = metadata[metadata_column]
+                    del extra[metadata_column]
+                else:
+                    values_stmt += ",null"
+
+            # Add JSON column and/or close statement
+            insert_stmt += (
+                f", {self.metadata_json_column})" if self.metadata_json_column else ")"
+            )
+            if self.metadata_json_column:
+                values_stmt += ", :extra)"
+                values["extra"] = json.dumps(extra)
+            else:
+                values_stmt += ")"
+
+            query = insert_stmt + values_stmt
+            self.engine._execute(query, values)
+
+        return ids
+
+    def add_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        embeddings = self.embedding_service.embed_documents(list(texts))
+        ids = self._add_embeddings(
+            texts, embeddings, metadatas=metadatas, ids=ids, **kwargs
+        )
+        return ids
+
+    @classmethod
+    def from_texts(  # type: ignore[override]
+        cls: Type[MySQLVectorStore],
+        texts: List[str],
+        embedding: Embeddings,
+        engine: MySQLEngine,
+        table_name: str,
+        metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
+        content_column: str = "content",
+        embedding_column: str = "embedding",
+        metadata_columns: List[str] = [],
+        ignore_metadata_columns: Optional[List[str]] = None,
+        id_column: str = "langchain_id",
+        metadata_json_column: str = "langchain_metadata",
+        **kwargs: Any,
+    ):
+        vs = cls(
+            engine=engine,
+            embedding_service=embedding,
+            table_name=table_name,
+            content_column=content_column,
+            embedding_column=embedding_column,
+            metadata_columns=metadata_columns,
+            ignore_metadata_columns=ignore_metadata_columns,
+            id_column=id_column,
+            metadata_json_column=metadata_json_column,
+        )
+        vs.add_texts(texts, metadatas=metadatas, ids=ids, **kwargs)
+        return vs
+
+    @classmethod
+    def from_documents(  # type: ignore[override]
+        cls: Type[MySQLVectorStore],
+        documents: List[Document],
+        embedding: Embeddings,
+        engine: MySQLEngine,
+        table_name: str,
+        ids: Optional[List[str]] = None,
+        content_column: str = "content",
+        embedding_column: str = "embedding",
+        metadata_columns: List[str] = [],
+        ignore_metadata_columns: Optional[List[str]] = None,
+        id_column: str = "langchain_id",
+        metadata_json_column: str = "langchain_metadata",
+        **kwargs: Any,
+    ) -> MySQLVectorStore:
+        vs = cls(
+            engine=engine,
+            embedding_service=embedding,
+            table_name=table_name,
+            content_column=content_column,
+            embedding_column=embedding_column,
+            metadata_columns=metadata_columns,
+            ignore_metadata_columns=ignore_metadata_columns,
+            id_column=id_column,
+            metadata_json_column=metadata_json_column,
+        )
+        texts = [doc.page_content for doc in documents]
+        metadatas = [doc.metadata for doc in documents]
+        vs.add_texts(texts, metadatas=metadatas, ids=ids, **kwargs)
+        return vs
+
+    def similarity_search(
+        self,
+        query: str,
+        k: Optional[int] = None,
+        filter: Optional[str] = None,
+        **kwargs: Any,
+    ):
+        raise NotImplementedError

--- a/src/langchain_google_cloud_sql_mysql/vectorstore.py
+++ b/src/langchain_google_cloud_sql_mysql/vectorstore.py
@@ -38,7 +38,7 @@ class MySQLVectorStore(VectorStore):
         ignore_metadata_columns: Optional[List[str]] = None,
         id_column: str = "langchain_id",
         metadata_json_column: Optional[str] = "langchain_metadata",
-        index_query_options: Optional[QueryOptions] = None,
+        query_options: Optional[QueryOptions] = None,
     ):
         """Constructor for MySQLVectorStore.
         Args:
@@ -117,7 +117,7 @@ class MySQLVectorStore(VectorStore):
         self.metadata_columns = metadata_columns
         self.id_column = id_column
         self.metadata_json_column = metadata_json_column
-        self.index_query_options = index_query_options
+        self.query_options = query_options
 
     @property
     def embeddings(self) -> Embeddings:

--- a/tests/integration/test_mysql_vectorstore.py
+++ b/tests/integration/test_mysql_vectorstore.py
@@ -60,7 +60,7 @@ class TestVectorStore:
 
     @pytest.fixture(scope="module")
     def db_name(self) -> str:
-        return get_env_var("DATABASE_ID", "database for cloud sql")
+        return get_env_var("DATABASE_ID", "database name on cloud sql instance")
 
     @pytest.fixture(scope="class")
     def engine(self, db_project, db_region, db_instance, db_name):

--- a/tests/integration/test_mysql_vectorstore.py
+++ b/tests/integration/test_mysql_vectorstore.py
@@ -1,0 +1,175 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import uuid
+
+import pytest
+import pytest_asyncio
+from langchain_community.embeddings import DeterministicFakeEmbedding
+from langchain_core.documents import Document
+
+from langchain_google_cloud_sql_mysql import Column, MySQLEngine, MySQLVectorStore
+
+DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
+CUSTOM_TABLE = "test-table-custom" + str(uuid.uuid4())
+VECTOR_SIZE = 768
+
+embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
+
+texts = ["foo", "bar", "baz"]
+metadatas = [{"page": str(i), "source": "google.com"} for i in range(len(texts))]
+docs = [
+    Document(page_content=texts[i], metadata=metadatas[i]) for i in range(len(texts))
+]
+
+embeddings = [embeddings_service.embed_query(texts[i]) for i in range(len(texts))]
+
+
+def get_env_var(key: str, desc: str) -> str:
+    v = os.environ.get(key)
+    if v is None:
+        raise ValueError(f"Must set env var {key} to: {desc}")
+    return v
+
+
+@pytest.mark.asyncio(scope="class")
+class TestVectorStore:
+    @pytest.fixture(scope="module")
+    def db_project(self) -> str:
+        return get_env_var("PROJECT_ID", "project id for google cloud")
+
+    @pytest.fixture(scope="module")
+    def db_region(self) -> str:
+        return get_env_var("REGION", "region for cloud sql instance")
+
+    @pytest.fixture(scope="module")
+    def db_instance(self) -> str:
+        return get_env_var("INSTANCE_ID", "instance for cloud sql")
+
+    @pytest.fixture(scope="module")
+    def db_name(self) -> str:
+        return get_env_var("DATABASE_ID", "database for cloud sql")
+
+    @pytest.fixture(scope="class")
+    def engine(self, db_project, db_region, db_instance, db_name):
+        engine = MySQLEngine.from_instance(
+            project_id=db_project,
+            instance=db_instance,
+            region=db_region,
+            database=db_name,
+        )
+
+        yield engine
+
+    @pytest.fixture(scope="class")
+    def vs(self, engine):
+        engine.init_vectorstore_table(DEFAULT_TABLE, VECTOR_SIZE)
+
+        vs = MySQLVectorStore(
+            engine,
+            embedding_service=embeddings_service,
+            table_name=DEFAULT_TABLE,
+        )
+        yield vs
+        engine._execute(f"DROP TABLE IF EXISTS `{DEFAULT_TABLE}`")
+
+    @pytest.fixture(scope="class")
+    def vs_custom(self, engine):
+        engine.init_vectorstore_table(
+            CUSTOM_TABLE,
+            VECTOR_SIZE,
+            id_column="myid",
+            content_column="mycontent",
+            embedding_column="myembedding",
+            metadata_columns=[Column("page", "TEXT"), Column("source", "TEXT")],
+            metadata_json_column="mymeta",
+        )
+        vs = MySQLVectorStore(
+            engine,
+            embedding_service=embeddings_service,
+            table_name=CUSTOM_TABLE,
+            id_column="myid",
+            content_column="mycontent",
+            embedding_column="myembedding",
+            metadata_columns=["page", "source"],
+            metadata_json_column="mymeta",
+        )
+        yield vs
+        engine._execute(f'DROP TABLE IF EXISTS `{CUSTOM_TABLE}`')
+
+    def test_post_init(self, engine):
+        with pytest.raises(ValueError):
+            MySQLVectorStore(
+                engine,
+                embedding_service=embeddings_service,
+                table_name=CUSTOM_TABLE,
+                id_column="myid",
+                content_column="noname",
+                embedding_column="myembedding",
+                metadata_columns=["page", "source"],
+                metadata_json_column="mymeta",
+            )
+
+    def test_add_texts(self, engine, vs):
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        vs.add_texts(texts, ids=ids)
+        results = engine._fetch(f"SELECT * FROM `{DEFAULT_TABLE}`")
+        assert len(results) == 3
+
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        vs.add_texts(texts, metadatas, ids)
+        results = engine._fetch(f"SELECT * FROM `{DEFAULT_TABLE}`")
+        assert len(results) == 6
+        engine._execute(f"TRUNCATE TABLE `{DEFAULT_TABLE}`")
+
+    def test_add_texts_edge_cases(self, engine, vs):
+        texts = ["Taylor's", '"Swift"', "best-friend"]
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        vs.add_texts(texts, ids=ids)
+        results = engine._fetch(f"SELECT * FROM `{DEFAULT_TABLE}`")
+        assert len(results) == 3
+        engine._execute(f"TRUNCATE TABLE `{DEFAULT_TABLE}`")
+
+    def test_add_embedding(self, engine, vs):
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        vs._add_embeddings(texts, embeddings, metadatas, ids)
+        results = engine._fetch(f"SELECT * FROM `{DEFAULT_TABLE}`")
+        assert len(results) == 3
+        engine._execute(f"TRUNCATE TABLE `{DEFAULT_TABLE}`")
+
+    def test_add_texts_custom(self, engine, vs_custom):
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        vs_custom.add_texts(texts, ids=ids)
+        results = engine._fetch(f'SELECT * FROM `{CUSTOM_TABLE}`')
+        assert len(results) == 3
+        assert results[0]["mycontent"] == "foo"
+        assert results[0]["myembedding"]
+        assert results[0]["page"] is None
+        assert results[0]["source"] is None
+
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        vs_custom.add_texts(texts, metadatas, ids)
+        results = engine._fetch(f'SELECT * FROM `{CUSTOM_TABLE}`')
+        assert len(results) == 6
+        engine._execute(f'TRUNCATE TABLE `{CUSTOM_TABLE}`')
+
+    def test_add_embedding_custom(self, engine, vs_custom):
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        vs_custom._add_embeddings(texts, embeddings, metadatas, ids)
+        results = engine._fetch(f'SELECT * FROM `{CUSTOM_TABLE}`')
+        assert len(results) == 3
+        engine._execute(f'TRUNCATE TABLE `{CUSTOM_TABLE}`')
+
+    # Need tests for store metadata=False

--- a/tests/integration/test_mysql_vectorstore.py
+++ b/tests/integration/test_mysql_vectorstore.py
@@ -107,7 +107,7 @@ class TestVectorStore:
             metadata_json_column="mymeta",
         )
         yield vs
-        engine._execute(f'DROP TABLE IF EXISTS `{CUSTOM_TABLE}`')
+        engine._execute(f"DROP TABLE IF EXISTS `{CUSTOM_TABLE}`")
 
     def test_post_init(self, engine):
         with pytest.raises(ValueError):
@@ -152,7 +152,7 @@ class TestVectorStore:
     def test_add_texts_custom(self, engine, vs_custom):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         vs_custom.add_texts(texts, ids=ids)
-        results = engine._fetch(f'SELECT * FROM `{CUSTOM_TABLE}`')
+        results = engine._fetch(f"SELECT * FROM `{CUSTOM_TABLE}`")
         assert len(results) == 3
         assert results[0]["mycontent"] == "foo"
         assert results[0]["myembedding"]
@@ -161,15 +161,15 @@ class TestVectorStore:
 
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         vs_custom.add_texts(texts, metadatas, ids)
-        results = engine._fetch(f'SELECT * FROM `{CUSTOM_TABLE}`')
+        results = engine._fetch(f"SELECT * FROM `{CUSTOM_TABLE}`")
         assert len(results) == 6
-        engine._execute(f'TRUNCATE TABLE `{CUSTOM_TABLE}`')
+        engine._execute(f"TRUNCATE TABLE `{CUSTOM_TABLE}`")
 
     def test_add_embedding_custom(self, engine, vs_custom):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         vs_custom._add_embeddings(texts, embeddings, metadatas, ids)
-        results = engine._fetch(f'SELECT * FROM `{CUSTOM_TABLE}`')
+        results = engine._fetch(f"SELECT * FROM `{CUSTOM_TABLE}`")
         assert len(results) == 3
-        engine._execute(f'TRUNCATE TABLE `{CUSTOM_TABLE}`')
+        engine._execute(f"TRUNCATE TABLE `{CUSTOM_TABLE}`")
 
     # Need tests for store metadata=False

--- a/tests/integration/test_mysql_vectorstore.py
+++ b/tests/integration/test_mysql_vectorstore.py
@@ -71,9 +71,13 @@ class TestVectorStore:
 
         yield engine
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="function")
     def vs(self, engine):
-        engine.init_vectorstore_table(DEFAULT_TABLE, VECTOR_SIZE)
+        engine.init_vectorstore_table(
+            DEFAULT_TABLE,
+            VECTOR_SIZE,
+            overwrite_existing=True,
+        )
 
         vs = MySQLVectorStore(
             engine,
@@ -83,7 +87,7 @@ class TestVectorStore:
         yield vs
         engine._execute(f"DROP TABLE IF EXISTS `{DEFAULT_TABLE}`")
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="function")
     def vs_custom(self, engine):
         engine.init_vectorstore_table(
             CUSTOM_TABLE,
@@ -93,7 +97,9 @@ class TestVectorStore:
             embedding_column="myembedding",
             metadata_columns=[Column("page", "TEXT"), Column("source", "TEXT")],
             metadata_json_column="mymeta",
+            overwrite_existing=True,
         )
+
         vs = MySQLVectorStore(
             engine,
             embedding_service=embeddings_service,

--- a/tests/integration/test_mysql_vectorstore_from_methods.py
+++ b/tests/integration/test_mysql_vectorstore_from_methods.py
@@ -61,7 +61,7 @@ class TestVectorStoreFromMethods:
 
     @pytest.fixture(scope="module")
     def db_name(self) -> str:
-        return get_env_var("DATABASE_ID", "instance for cloud sql")
+        return get_env_var("DATABASE_ID", "database name on cloud sql instance")
 
     @pytest.fixture
     async def engine(self, db_project, db_region, db_instance, db_name):

--- a/tests/integration/test_mysql_vectorstore_from_methods.py
+++ b/tests/integration/test_mysql_vectorstore_from_methods.py
@@ -132,7 +132,6 @@ class TestVectorStoreFromMethods:
         assert results[0]["page"] is None
         assert results[0]["source"] is None
 
-
     def test_from_docs_custom(self, engine):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         docs = [

--- a/tests/integration/test_mysql_vectorstore_from_methods.py
+++ b/tests/integration/test_mysql_vectorstore_from_methods.py
@@ -16,7 +16,6 @@ import os
 import uuid
 
 import pytest
-import pytest_asyncio
 from langchain_community.embeddings import DeterministicFakeEmbedding
 from langchain_core.documents import Document
 
@@ -45,7 +44,6 @@ def get_env_var(key: str, desc: str) -> str:
     return v
 
 
-@pytest.mark.asyncio
 class TestVectorStoreFromMethods:
     @pytest.fixture(scope="module")
     def db_project(self) -> str:
@@ -61,10 +59,10 @@ class TestVectorStoreFromMethods:
 
     @pytest.fixture(scope="module")
     def db_name(self) -> str:
-        return get_env_var("DATABASE_ID", "database name on cloud sql instance")
+        return get_env_var("DB_NAME", "database name on cloud sql instance")
 
     @pytest.fixture
-    async def engine(self, db_project, db_region, db_instance, db_name):
+    def engine(self, db_project, db_region, db_instance, db_name):
         engine = MySQLEngine.from_instance(
             project_id=db_project,
             instance=db_instance,
@@ -126,8 +124,11 @@ class TestVectorStoreFromMethods:
             metadata_columns=["page", "source"],
         )
         results = engine._fetch(f"SELECT * FROM `{CUSTOM_TABLE}`")
+        content = [result["mycontent"] for result in results]
         assert len(results) == 3
-        assert results[0]["mycontent"] == "foo"
+        assert "foo" in content
+        assert "bar" in content
+        assert "baz" in content
         assert results[0]["myembedding"]
         assert results[0]["page"] is None
         assert results[0]["source"] is None
@@ -154,8 +155,11 @@ class TestVectorStoreFromMethods:
         )
 
         results = engine._fetch(f"SELECT * FROM `{CUSTOM_TABLE}`")
+        content = [result["mycontent"] for result in results]
         assert len(results) == 3
-        assert results[0]["mycontent"] == "foo"
+        assert "foo" in content
+        assert "bar" in content
+        assert "baz" in content
         assert results[0]["myembedding"]
         assert results[0]["page"] == "0"
         assert results[0]["source"] == "google.com"

--- a/tests/integration/test_mysql_vectorstore_from_methods.py
+++ b/tests/integration/test_mysql_vectorstore_from_methods.py
@@ -161,6 +161,9 @@ class TestVectorStoreFromMethods:
         assert "bar" in content
         assert "baz" in content
         assert results[0]["myembedding"]
-        assert results[0]["page"] == "0"
+        pages = [result["page"] for result in results]
+        assert "0" in pages
+        assert "1" in pages
+        assert "2" in pages
         assert results[0]["source"] == "google.com"
         engine._execute(f"TRUNCATE TABLE `{CUSTOM_TABLE}`")

--- a/tests/integration/test_mysql_vectorstore_from_methods.py
+++ b/tests/integration/test_mysql_vectorstore_from_methods.py
@@ -1,0 +1,163 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import uuid
+
+import pytest
+import pytest_asyncio
+from langchain_community.embeddings import DeterministicFakeEmbedding
+from langchain_core.documents import Document
+
+from langchain_google_cloud_sql_mysql import Column, MySQLEngine, MySQLVectorStore
+
+DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
+CUSTOM_TABLE = "test_table_custom" + str(uuid.uuid4()).replace("-", "_")
+VECTOR_SIZE = 768
+
+
+embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
+
+texts = ["foo", "bar", "baz"]
+metadatas = [{"page": str(i), "source": "google.com"} for i in range(len(texts))]
+docs = [
+    Document(page_content=texts[i], metadata=metadatas[i]) for i in range(len(texts))
+]
+
+embeddings = [embeddings_service.embed_query(texts[i]) for i in range(len(texts))]
+
+
+def get_env_var(key: str, desc: str) -> str:
+    v = os.environ.get(key)
+    if v is None:
+        raise ValueError(f"Must set env var {key} to: {desc}")
+    return v
+
+
+@pytest.mark.asyncio
+class TestVectorStoreFromMethods:
+    @pytest.fixture(scope="module")
+    def db_project(self) -> str:
+        return get_env_var("PROJECT_ID", "project id for google cloud")
+
+    @pytest.fixture(scope="module")
+    def db_region(self) -> str:
+        return get_env_var("REGION", "region for cloud sql instance")
+
+    @pytest.fixture(scope="module")
+    def db_instance(self) -> str:
+        return get_env_var("INSTANCE_ID", "instance for cloud sql")
+
+    @pytest.fixture(scope="module")
+    def db_name(self) -> str:
+        return get_env_var("DATABASE_ID", "instance for cloud sql")
+
+    @pytest.fixture
+    async def engine(self, db_project, db_region, db_instance, db_name):
+        engine = MySQLEngine.from_instance(
+            project_id=db_project,
+            instance=db_instance,
+            region=db_region,
+            database=db_name,
+        )
+        engine.init_vectorstore_table(DEFAULT_TABLE, VECTOR_SIZE)
+        engine.init_vectorstore_table(
+            CUSTOM_TABLE,
+            VECTOR_SIZE,
+            id_column="myid",
+            content_column="mycontent",
+            embedding_column="myembedding",
+            metadata_columns=[Column("page", "TEXT"), Column("source", "TEXT")],
+            store_metadata=False,
+        )
+        yield engine
+        engine._execute(f"DROP TABLE IF EXISTS `{DEFAULT_TABLE}`")
+        engine._execute(f"DROP TABLE IF EXISTS `{CUSTOM_TABLE}`")
+
+    def test_from_texts(self, engine):
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        MySQLVectorStore.from_texts(
+            texts,
+            embeddings_service,
+            engine,
+            DEFAULT_TABLE,
+            metadatas=metadatas,
+            ids=ids,
+        )
+        results = engine._fetch(f"SELECT * FROM `{DEFAULT_TABLE}`")
+        assert len(results) == 3
+        engine._execute(f"TRUNCATE TABLE `{DEFAULT_TABLE}`")
+
+    def test_from_docs(self, engine):
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        MySQLVectorStore.from_documents(
+            docs,
+            embeddings_service,
+            engine,
+            DEFAULT_TABLE,
+            ids=ids,
+        )
+        results = engine._fetch(f"SELECT * FROM `{DEFAULT_TABLE}`")
+        assert len(results) == 3
+        engine._execute(f"TRUNCATE TABLE `{DEFAULT_TABLE}`")
+
+    def test_from_texts_custom(self, engine):
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        MySQLVectorStore.from_texts(
+            texts,
+            embeddings_service,
+            engine,
+            CUSTOM_TABLE,
+            ids=ids,
+            id_column="myid",
+            content_column="mycontent",
+            embedding_column="myembedding",
+            metadata_columns=["page", "source"],
+        )
+        results = engine._fetch(f"SELECT * FROM `{CUSTOM_TABLE}`")
+        assert len(results) == 3
+        assert results[0]["mycontent"] == "foo"
+        assert results[0]["myembedding"]
+        assert results[0]["page"] is None
+        assert results[0]["source"] is None
+
+
+    def test_from_docs_custom(self, engine):
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        docs = [
+            Document(
+                page_content=texts[i],
+                metadata={"page": str(i), "source": "google.com"},
+            )
+            for i in range(len(texts))
+        ]
+        MySQLVectorStore.from_documents(
+            docs,
+            embeddings_service,
+            engine,
+            CUSTOM_TABLE,
+            ids=ids,
+            id_column="myid",
+            content_column="mycontent",
+            embedding_column="myembedding",
+            metadata_columns=["page", "source"],
+        )
+
+        results = engine._fetch(f"SELECT * FROM `{CUSTOM_TABLE}`")
+        assert len(results) == 3
+        assert results[0]["mycontent"] == "foo"
+        assert results[0]["myembedding"]
+        assert results[0]["page"] == "0"
+        assert results[0]["source"] == "google.com"
+        engine._execute(f"TRUNCATE TABLE `{CUSTOM_TABLE}`")


### PR DESCRIPTION
Adding `MySQLVectorStore` and all the different class methods to initialize it.

Example usage:
```python
from langchain_google_cloud_sql_mysql import  MySQLEngine, MySQLVectorStore

# create connection pool engine
engine = MySQLEngine.from_instance("my-project-id", "us-central1", "my-instance", "my-database")

# initialize vector store table
engine.init_vectorstore_table(table_name="vector_store", vector_size=768)

# base constructor
vector_store = MySQLVectorStore(
    engine,
    embedding_service=embeddings_service,
    table_name="vector_store",
)

# create VectorStore from LangChain Documents
vector_store = MySQLVectorStore.from_documents(
    docs,
    embedding=embeddings_service,
    engine=engine,
    table_name="vector_store",
    ids=ids,
)

# create VectorStore from texts
vector_store = MySQLVectorStore.from_texts(
    texts,
    embedding=embeddings_service,
    engine=engine,
    table_name="vector_store",
    metadatas=metadatas,
    ids=ids,
)
```