### PR TITLE
docs: add end-to-end MySQL quickstart

### DIFF
--- a/samples/langchain_quick_start.ipynb
+++ b/samples/langchain_quick_start.ipynb
@@ -179,15 +179,7 @@
     },
     "outputId": "be1ad33c-9647-43c0-9722-dbccea26dcae"
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Updated property [core/project].\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# @markdown Please fill in the value below with your GCP project ID and then run the cell.\n",
     "\n",
@@ -948,14 +940,6 @@
     "outputId": "593133a2-424a-4551-f637-1e3391405a2b"
    },
    "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "/usr/local/lib/python3.10/dist-packages/langchain_core/_api/deprecation.py:117: LangChainDeprecationWarning: The function `__call__` was deprecated in LangChain 0.1.0 and will be removed in 0.2.0. Use invoke instead.\n",
-      "  warn_deprecated(\n"
-     ]
-    },
     {
      "output_type": "stream",
      "name": "stdout",

--- a/samples/langchain_quick_start.ipynb
+++ b/samples/langchain_quick_start.ipynb
@@ -1,0 +1,1046 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "6zvUr-Qev6lL"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2024 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ob11AkrStrRI"
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/googleapis/langchain-google-cloud-sql-mysql-python/blob/main/samples/langchain_quick_start.ipynb)\n",
+    "\n",
+    "---\n",
+    "# **Introduction**\n",
+    "\n",
+    "In this codelab, you'll learn how to create a powerful interactive generative AI application using Retrieval Augmented Generation powered by [Cloud SQL for MySQL](https://cloud.google.com/sql/docs/mysql) and [LangChain](https://www.langchain.com/). We will be creating an application grounded in a [Netflix Movie dataset](https://www.kaggle.com/datasets/shivamb/netflix-shows), allowing you to interact with movie data in exciting new ways."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Ma6pEng3ypbA"
+   },
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "* A basic understanding of the Google Cloud Console\n",
+    "* Basic skills in command line interface and Google Cloud shell\n",
+    "* Basic Python knowledge"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "DzDgqJHgysy1"
+   },
+   "source": [
+    "## What you'll learn\n",
+    "\n",
+    "* How to deploy a Cloud SQL for MySQL instance\n",
+    "* How to use Cloud SQL for MySQL as a DocumentLoader\n",
+    "* How to use Cloud SQL for MySQL as a VectorStore\n",
+    "* How to use Cloud SQL for MySQL for ChatMessageHistory storage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FbcZUjT1yvTq"
+   },
+   "source": [
+    "## What you'll need\n",
+    "* A Google Cloud Account and Google Cloud Project\n",
+    "* A web browser such as [Chrome](https://www.google.com/chrome/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vHdR4fF3vLWA"
+   },
+   "source": [
+    "# **Setup and Requirements**\n",
+    "\n",
+    "In the following instructions you will learn to:\n",
+    "1. Install required dependencies for our application\n",
+    "2. Set up authentication for our project\n",
+    "3. Set up a Cloud SQL for MySQL Instance\n",
+    "4. Import the data used by our application"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "uy9KqgPQ4GBi"
+   },
+   "source": [
+    "## Install dependencies\n",
+    "First you will need to install the dependencies needed to run this demo app."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "M_ppDxYf4Gqs"
+   },
+   "outputs": [],
+   "source": [
+    "%pip install --upgrade --quiet langchain-google-cloud-sql-mysql langchain-google-vertexai langchain"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FXK81xEmYU5z"
+   },
+   "source": [
+    "**Colab only:** Uncomment the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "7gyv1anhYU5z"
+   },
+   "outputs": [],
+   "source": [
+    "# Automatically restart kernel after installs so that your environment can access the new packages\n",
+    "import IPython\n",
+    "\n",
+    "app = IPython.Application.instance()\n",
+    "app.kernel.do_shutdown(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "DeUbHclxw7_l"
+   },
+   "source": [
+    "## Authenticate to Google Cloud within Colab\n",
+    "In order to access your Google Cloud Project from this notebook, you will need to Authenticate as an IAM user."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "a168rJE1xDHO"
+   },
+   "outputs": [],
+   "source": [
+    "from google.colab import auth\n",
+    "\n",
+    "auth.authenticate_user()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "UCiNGP1Qxd6x"
+   },
+   "source": [
+    "## Connect Your Google Cloud Project\n",
+    "Time to connect your Google Cloud Project to this notebook so that you can leverage Google Cloud from within Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "cellView": "form",
+    "id": "qjFuhRhVxlWP",
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "outputId": "be1ad33c-9647-43c0-9722-dbccea26dcae"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Updated property [core/project].\n"
+     ]
+    }
+   ],
+   "source": [
+    "# @markdown Please fill in the value below with your GCP project ID and then run the cell.\n",
+    "\n",
+    "# Please fill in these values.\n",
+    "PROJECT_ID = \"\"  # @param {type:\"string\"}\n",
+    "\n",
+    "# Quick input validations.\n",
+    "assert PROJECT_ID, \"⚠️ Please provide a Google Cloud project ID\"\n",
+    "\n",
+    "# Configure gcloud.\n",
+    "!gcloud config set project {PROJECT_ID}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "O-oqMC5Ox-ZM"
+   },
+   "source": [
+    "## Configure Your Google Cloud Project\n",
+    "\n",
+    "Configure the following in your Google Cloud Project."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yjMjTGg7YU51"
+   },
+   "source": [
+    "1. IAM principal (user, service account, etc.) with the [Cloud SQL Client][client-role] role. The user logged into this notebook will be used as the IAM principal and will be granted the Cloud SQL Client role.\n",
+    "\n",
+    "[client-role]: https://cloud.google.com/sql/docs/mysql/roles-and-permissions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "xOnUO-5gYU51"
+   },
+   "outputs": [],
+   "source": [
+    "current_user = !gcloud auth list --filter=status:ACTIVE --format=\"value(account)\"\n",
+    "!gcloud projects add-iam-policy-binding {PROJECT_ID} \\\n",
+    "  --member=user:{current_user[0]} \\\n",
+    "  --role=\"roles/cloudsql.client\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ieb_vqHKYU51"
+   },
+   "source": [
+    "2. Enable the APIs for Cloud SQL and Vertex AI within your project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "CKWrwyfzyTwH"
+   },
+   "outputs": [],
+   "source": [
+    "# Enable GCP services\n",
+    "!gcloud services enable sqladmin.googleapis.com aiplatform.googleapis.com"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Gn8g7-wCyZU6"
+   },
+   "source": [
+    "## Set up Cloud SQL\n",
+    "You will need a **MySQL** Cloud SQL instance for the following stages of this notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "T616pEOUygYQ"
+   },
+   "source": [
+    "### Create a MySQL Instance\n",
+    "Running the below cell will verify the existence of the Cloud SQL instance and or create a new instance if one does not exist.\n",
+    "\n",
+    "A database named `langchain_db` will be created and used for the rest of the quickstart.\n",
+    "\n",
+    "**Note:** MySQL vector support is only available on MySQL instances with version >= 8.0.36\n",
+    "\n",
+    "> ⏳ - Creating a Cloud SQL instance may take a few minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "id": "XXI1uUu3y8gc"
+   },
+   "outputs": [],
+   "source": [
+    "#@markdown Please fill in the both the Google Cloud region and name of your Cloud SQL instance. Once filled in, run the cell.\n",
+    "\n",
+    "# Please fill in these values.\n",
+    "REGION = \"us-central1\" #@param {type:\"string\"}\n",
+    "INSTANCE_NAME = \"langchain-quickstart-instance\" #@param {type:\"string\"}\n",
+    "DATABASE_NAME = \"langchain_db\"\n",
+    "PASSWORD = input(\"Please provide a password to be used for 'root' database user: \")\n",
+    "\n",
+    "# Quick input validations.\n",
+    "assert REGION, \"⚠️ Please provide a Google Cloud region\"\n",
+    "assert INSTANCE_NAME, \"⚠️ Please provide the name of your instance\"\n",
+    "assert DATABASE_NAME, \"⚠️ Please provide the name of your database\"\n",
+    "\n",
+    "# check if Cloud SQL instance exists in the provided region\n",
+    "database_version = !gcloud sql instances describe {INSTANCE_NAME} --format=\"value(databaseVersion)\"\n",
+    "if database_version[0].startswith(\"MYSQL\"):\n",
+    "  print(\"Found existing MySQL Cloud SQL Instance!\")\n",
+    "else:\n",
+    "  print(\"Creating new Cloud SQL instance...\")\n",
+    "  !gcloud sql instances create {INSTANCE_NAME} --database-version=MYSQL_8_0_36 \\\n",
+    "    --region={REGION} --cpu=1 --memory=4GB --root-password={PASSWORD} \\\n",
+    "    --database-flags=cloudsql_iam_authentication=On\n",
+    "\n",
+    "databases = !gcloud sql databases list --instance={INSTANCE_NAME} --format=\"value(name)\"\n",
+    "if DATABASE_NAME not in databases:\n",
+    "  print(\"Creating 'langchain_db' database for the quickstart...\")\n",
+    "  !gcloud sql databases create {DATABASE_NAME} --instance={INSTANCE_NAME}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HdolCWyatZmG"
+   },
+   "source": [
+    "## Import data to your database\n",
+    "\n",
+    "Now that you have your database, you will need to import data! We will be using a [Netflix Dataset from Kaggle](https://www.kaggle.com/datasets/shivamb/netflix-shows). Here is what the data looks like:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "36-FBKzJ-tLa"
+   },
+   "source": [
+    "| show_id | type    | title                | director         | cast                                                                                                                                                  | country       | date_added        | release_year | rating | duration  | listed_in                                    | description                                                                                                                                                                           |\n",
+    "|---------|---------|----------------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|-------------------|--------------|--------|-----------|----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|\n",
+    "| s1      | Movie   | Dick Johnson Is Dead | Kirsten Johnson  |                                                                                                                                                        | United States | September 25, 2021 | 2020         | PG-13  | 90 min    | Documentaries                                | As her father nears the end of his life, filmmaker Kirsten Johnson stages his death in inventive and comical ways to help them both face the inevitable.                              |\n",
+    "| s2      | TV Show | Blood & Water        |                  | Ama Qamata, Khosi Ngema, Gail Mabalane, Thabang Molaba, Dillon Windvogel, Natasha Thahane, Arno Greeff, Xolile Tshabalala, Getmore Sithole, Cindy Mahlangu, Ryle De Morny, Greteli Fincham, Sello Maake Ka-Ncube, Odwa Gwanya, Mekaila Mathys, Sandi Schultz, Duane Williams, Shamilla Miller, Patrick Mofokeng | South Africa  | September 24, 2021 | 2021         | TV-MA  | 2 Seasons | International TV Shows, TV Dramas, TV Mysteries | After crossing paths at a party, a Cape Town teen sets out to prove whether a private-school swimming star is her sister who was abducted at birth.                                   |\n",
+    "| s3      | TV Show | Ganglands            | Julien Leclercq  | Sami Bouajila, Tracy Gotoas, Samuel Jouy, Nabiha Akkari, Sofia Lesaffre, Salim Kechiouche, Noureddine Farihi, Geert Van Rampelberg, Bakary Diombera                                   |               | September 24, 2021 | 2021         | TV-MA  | 1 Season  | Crime TV Shows, International TV Shows, TV Action & Adventure | To protect his family from a powerful drug lord, skilled thief Mehdi and his expert team of robbers are pulled into a violent and deadly turf war.                                     |\n",
+    "| s4      | TV Show | Jailbirds New Orleans |                  |                                                                                                                                                        |               | September 24, 2021 | 2021         | TV-MA  | 1 Season  | Docuseries, Reality TV                        | Feuds, flirtations and toilet talk go down among the incarcerated women at the Orleans Justice Center in New Orleans on this gritty reality series.                                   |\n",
+    "| s5      | TV Show | Kota Factory         |                  | Mayur More, Jitendra Kumar, Ranjan Raj, Alam Khan, Ahsaas Channa, Revathi Pillai, Urvi Singh, Arun Kumar                                                 | India        | September 24, 2021 | 2021         | TV-MA  | 2 Seasons | International TV Shows, Romantic TV Shows, TV Comedies | In a city of coaching centers known to train India’s finest collegiate minds, an earnest but unexceptional student and his friends navigate campus life. |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "kQ2KWsYI_Msa"
+   },
+   "source": [
+    "You won't need to directly load the csv data into your database. Instead we prepared a table, \"netflix_titles\", in the format of a `.sql` file for MySQL. You can easily import the table into your database with one `gcloud` command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qbLhv9jgD8nm"
+   },
+   "outputs": [],
+   "source": [
+    "# Import the Netflix titles table using gcloud command\n",
+    "import_command_output = !gcloud sql import sql {INSTANCE_NAME} gs://cloud-samples-data/langchain/cloud-sql/mysql/netflix_titles.sql --database={DATABASE_NAME} --quiet\n",
+    "\n",
+    "if \"Imported data\" in str(import_command_output):\n",
+    "    print(import_command_output)\n",
+    "elif \"already exists\" in str(import_command_output):\n",
+    "    print(\"Did not import because the table already existed.\")\n",
+    "else:\n",
+    "    raise Exception(f\"The import seems to have failed:\\n{import_command_output}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "SsGS80H04bDN"
+   },
+   "source": [
+    "# **Use case 1: Cloud SQL for MySQL as a document loader**\n",
+    "\n",
+    "Now that you have data in your database, you are ready to use Cloud SQL for MySQL as a [document loader](https://python.langchain.com/docs/modules/data_connection/document_loaders/). This means we will pull data from the database and load it into memory as documents. We can then feed these documents into the vector store."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-CQgPON8dwSK"
+   },
+   "source": [
+    "Next let's connect to our Cloud SQL MySQL instance using the `MySQLEngine` class from the `langchain-google-cloud-sql-mysql` package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "id": "zrwTsWHMkQ_v"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_google_cloud_sql_mysql import MySQLEngine\n",
+    "\n",
+    "mysql_engine = MySQLEngine.from_instance(\n",
+    "    project_id=PROJECT_ID,\n",
+    "    instance=INSTANCE_NAME,\n",
+    "    region=REGION,\n",
+    "    database=DATABASE_NAME,\n",
+    "    user=\"root\",\n",
+    "    password=PASSWORD,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8s-C0P-Oee69"
+   },
+   "source": [
+    "Once we initialize a MySQLEngine object, we can pass it into the `MySQLLoader` to connect to a specific database. As you can see we also pass in a query, table_name and a list of columns. The query tells the loader what query to use to pull data. The \"content_columns\" argument refers to the columns that will be used as \"content\" in the document object we will later construct. The rest of the columns in that table will become the \"metadata\" associated with the documents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "2SdFJT6Vece1"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_google_cloud_sql_mysql import MySQLLoader\n",
+    "\n",
+    "table_name = \"netflix_titles\"\n",
+    "content_columns = [\"title\", \"director\", \"cast\", \"description\"]\n",
+    "loader = MySQLLoader(\n",
+    "    engine=mysql_engine,\n",
+    "    query=f\"SELECT * FROM `{table_name}`;\",\n",
+    "    content_columns=content_columns,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dsL-KFrmfuS1"
+   },
+   "source": [
+    "Then let's load our documents from our database using our document loader. You can see the first 5 documents from the database here. Nice, you just used Cloud SQL for MySQL as a LangChain document loader!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "t4zTx-HLfwmW",
+    "outputId": "88dc2827-d735-4ae8-9f1d-db4e0e0c9b63"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Loaded 8807 documents from the database. \n",
+      "5 Examples:\n",
+      "page_content='Dick Johnson Is Dead Kirsten Johnson  As her father nears the end of his life, filmmaker Kirsten Johnson stages his death in inventive and comical ways to help them both face the inevitable.' metadata={'show_id': 's1', 'type': 'Movie', 'country': 'United States', 'date_added': 'September 25, 2021', 'release_year': 2020, 'rating': 'PG-13', 'duration': '90 min', 'listed_in': 'Documentaries'}\n",
+      "page_content='Blood & Water  Ama Qamata, Khosi Ngema, Gail Mabalane, Thabang Molaba, Dillon Windvogel, Natasha Thahane, Arno Greeff, Xolile Tshabalala, Getmore Sithole, Cindy Mahlangu, Ryle De Morny, Greteli Fincham, Sello Maake Ka-Ncube, Odwa Gwanya, Mekaila Mathys, Sandi Schultz, Duane Williams, Shamilla Miller, Patrick Mofokeng After crossing paths at a party, a Cape Town teen sets out to prove whether a private-school swimming star is her sister who was abducted at birth.' metadata={'show_id': 's2', 'type': 'TV Show', 'country': 'South Africa', 'date_added': 'September 24, 2021', 'release_year': 2021, 'rating': 'TV-MA', 'duration': '2 Seasons', 'listed_in': 'International TV Shows, TV Dramas, TV Mysteries'}\n",
+      "page_content='Ganglands Julien Leclercq Sami Bouajila, Tracy Gotoas, Samuel Jouy, Nabiha Akkari, Sofia Lesaffre, Salim Kechiouche, Noureddine Farihi, Geert Van Rampelberg, Bakary Diombera To protect his family from a powerful drug lord, skilled thief Mehdi and his expert team of robbers are pulled into a violent and deadly turf war.' metadata={'show_id': 's3', 'type': 'TV Show', 'country': '', 'date_added': 'September 24, 2021', 'release_year': 2021, 'rating': 'TV-MA', 'duration': '1 Season', 'listed_in': 'Crime TV Shows, International TV Shows, TV Action '}\n",
+      "page_content='Jailbirds New Orleans   Feuds, flirtations and toilet talk go down among the incarcerated women at the Orleans Justice Center in New Orleans on this gritty reality series.' metadata={'show_id': 's4', 'type': 'TV Show', 'country': '', 'date_added': 'September 24, 2021', 'release_year': 2021, 'rating': 'TV-MA', 'duration': '1 Season', 'listed_in': 'Docuseries, Reality TV'}\n",
+      "page_content='Kota Factory  Mayur More, Jitendra Kumar, Ranjan Raj, Alam Khan, Ahsaas Channa, Revathi Pillai, Urvi Singh, Arun Kumar In a city of coaching centers known to train India’s finest collegiate minds, an earnest but unexceptional student and his friends navigate campus life.' metadata={'show_id': 's5', 'type': 'TV Show', 'country': 'India', 'date_added': 'September 24, 2021', 'release_year': 2021, 'rating': 'TV-MA', 'duration': '2 Seasons', 'listed_in': 'International TV Shows, Romantic TV Shows, TV Come'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "documents = loader.load()\n",
+    "print(f\"Loaded {len(documents)} documents from the database. \\n5 Examples:\")\n",
+    "for doc in documents[:5]:\n",
+    "    print(doc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "z9uLV3bs4noo"
+   },
+   "source": [
+    "# **Use case 2: Cloud SQL for MySQL as a vector store**\n",
+    "\n",
+    "---\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "duVsSeMcgEWl"
+   },
+   "source": [
+    "Now, let's learn how to put all of the documents we just loaded into a [vector store](https://python.langchain.com/docs/modules/data_connection/vectorstores/) so that we can use vector search to answer our user's questions!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jfH8oQJ945Ko"
+   },
+   "source": [
+    "### Create Your Vector Store table\n",
+    "\n",
+    "Based on the documents that we loaded before, we want to create a table with a vector column as our vector store. We will start it by intializing a vector table by calling the `init_vectorstore_table` function from our `engine`. As you can see we list all of the columns for our metadata. We also specify a vector size, 768, that corresponds with the length of the vectors computed by the model our embeddings service uses, Vertex AI's textembedding-gecko.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "id": "e_rmjywG47pv"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_google_cloud_sql_mysql import Column\n",
+    "\n",
+    "vector_table_name = \"vector_netflix_titles\"\n",
+    "\n",
+    "mysql_engine.init_vectorstore_table(\n",
+    "    table_name=vector_table_name,\n",
+    "    vector_size=768,\n",
+    "    metadata_columns=[\n",
+    "        Column(\"show_id\", \"VARCHAR(50)\", nullable=True),\n",
+    "        Column(\"type\", \"VARCHAR(50)\", nullable=True),\n",
+    "        Column(\"country\", \"VARCHAR(50)\", nullable=True),\n",
+    "        Column(\"date_added\", \"VARCHAR(50)\", nullable=True),\n",
+    "        Column(\"release_year\", \"INTEGER\", nullable=True),\n",
+    "        Column(\"rating\", \"VARCHAR(50)\", nullable=True),\n",
+    "        Column(\"duration\", \"VARCHAR(50)\", nullable=True),\n",
+    "        Column(\"listed_in\", \"VARCHAR(50)\", nullable=True),\n",
+    "    ],\n",
+    "    overwrite_existing=True,  # Enabling this will recreate the table if exists.\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "KG6rwEuJLNIo"
+   },
+   "source": [
+    "### Try inserting the documents into the vector table\n",
+    "\n",
+    "Now we will create a vector_store object backed by our vector table in the Cloud SQL database. Let's load the data from the documents to the vector table. Note that for each row, the embedding service will be called to compute the embeddings to store in the vector table.\n",
+    "\n",
+    "Pricing details can be found [here](https://cloud.google.com/vertex-ai/pricing)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "id": "Wo4-7EYCIFF9"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_google_vertexai import VertexAIEmbeddings\n",
+    "from langchain_google_cloud_sql_mysql import MySQLVectorStore\n",
+    "\n",
+    "# Initialize the embedding service. In this case we are using version 003 of Vertex AI's textembedding-gecko model.\n",
+    "# In general, it is good practice to specify the model version used.\n",
+    "embeddings_service = VertexAIEmbeddings(\n",
+    "    model_name=\"textembedding-gecko@003\", project=PROJECT_ID\n",
+    ")\n",
+    "\n",
+    "vector_store = MySQLVectorStore(\n",
+    "    engine=mysql_engine,\n",
+    "    embedding_service=embeddings_service,\n",
+    "    table_name=vector_table_name,\n",
+    "    metadata_columns=[\n",
+    "        \"show_id\",\n",
+    "        \"type\",\n",
+    "        \"country\",\n",
+    "        \"date_added\",\n",
+    "        \"release_year\",\n",
+    "        \"duration\",\n",
+    "        \"listed_in\",\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fr1rP6KQ-8ag"
+   },
+   "source": [
+    "Now let's try to put the documents data into the vector table. Here is a code example to load the first 5 documents in the list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "CTks8Cy--93B"
+   },
+   "outputs": [],
+   "source": [
+    "import uuid\n",
+    "\n",
+    "docs_to_load = documents[:5]\n",
+    "\n",
+    "# ! Uncomment the following line to load all 8,800+ documents to the database vector table with calling the embedding service.\n",
+    "# docs_to_load = documents\n",
+    "\n",
+    "ids = [str(uuid.uuid4()) for i in range(len(docs_to_load))]\n",
+    "vector_store.add_documents(docs_to_load, ids)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "29iztdvfL2BN"
+   },
+   "source": [
+    "### Import the rest of your data into your vector table\n",
+    "\n",
+    "You don't have to call the embedding service 8,800 times to load all the documents for the demo. Instead, we have prepared a table with the all 8,800+ rows with pre-computed embeddings in a `.sql` file. Again, let's import to our DB using `gcloud` command.\n",
+    "\n",
+    "It will restore the `.sql` file to a table with vectors called `vector_netflix_titles`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "FEe9El7QMjHi"
+   },
+   "outputs": [],
+   "source": [
+    "# Import the netflix titles with vector table using gcloud command\n",
+    "import_command_output = !gcloud sql import sql {INSTANCE_NAME} gs://cloud-samples-data/langchain/cloud-sql/mysql/vector_netflix_titles.sql --database={DATABASE_NAME} --quiet\n",
+    "\n",
+    "if \"Imported data\" in str(import_command_output):\n",
+    "    print(import_command_output)\n",
+    "elif \"already exists\" in str(import_command_output):\n",
+    "    print(\"Did not import because the table already existed.\")\n",
+    "else:\n",
+    "    raise Exception(f\"The import seems failed:\\n{import_command_output}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ZM_OFzZrQEPs"
+   },
+   "source": [
+    "# **Use case 3: Cloud SQL for MySQL as Chat Memory**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dxqIPQtjDquk"
+   },
+   "source": [
+    "Next we will add chat history (called [“memory” in the context of LangChain](https://python.langchain.com/docs/modules/memory/)) to our application so the LLM can retain context and information across multiple interactions, leading to more coherent and sophisticated conversations or text generation. We can use Cloud SQL for PostgreSQL as “memory” storage in our application so that the LLM can use context from prior conversations to better answer the user’s prompts. First let's initialize Cloud SQL for MySQL as memory storage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "id": "vyYQILyoEAqg"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_google_cloud_sql_mysql import MySQLChatMessageHistory\n",
+    "\n",
+    "message_table_name = \"message_store\"\n",
+    "\n",
+    "mysql_engine.init_chat_history_table(table_name=message_table_name)\n",
+    "\n",
+    "chat_history = MySQLChatMessageHistory(\n",
+    "    mysql_engine,\n",
+    "    session_id=\"my-test-session\",\n",
+    "    table_name=message_table_name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2yuXYLTCl2K1"
+   },
+   "source": [
+    "Here is an example of how you would add a user message and how you would add an ai message."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "qDVoTWZal0ZF",
+    "outputId": "77ac1c76-8f81-4f31-b6f6-1cf3ad104b70"
+   },
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "[HumanMessage(content='Hi!'),\n",
+       " AIMessage(content=\"Hello there. I'm a model and am happy to help!\")]"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 14
+    }
+   ],
+   "source": [
+    "chat_history.add_user_message(\"Hi!\")\n",
+    "chat_history.add_ai_message(\"Hello there. I'm a model and am happy to help!\")\n",
+    "\n",
+    "chat_history.messages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "k0O9mta8RQ0v"
+   },
+   "source": [
+    "# **Conversational RAG Chain backed by Cloud SQL for MySQL**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "j2OxF3JoNA7J"
+   },
+   "source": [
+    "So far we've tested with using Cloud SQL for MySQL as document loader, vector store and chat memory. Now let's put it all together with a `ConversationalRetrievalChain`.\n",
+    "\n",
+    "We will build a chat bot that can answer movie related questions based on the vector search results.\n",
+    "\n",
+    "First let's initialize all of our MySQL engine object to use as a connection in our vector store and chat_history."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "id": "9ukjOO-sNQ8_"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_google_vertexai import VertexAIEmbeddings, VertexAI\n",
+    "from langchain.chains import ConversationalRetrievalChain\n",
+    "from langchain.memory import ConversationSummaryBufferMemory\n",
+    "from langchain_core.prompts import PromptTemplate\n",
+    "from langchain_google_cloud_sql_mysql import (\n",
+    "    MySQLChatMessageHistory,\n",
+    "    MySQLEngine,\n",
+    "    MySQLVectorStore,\n",
+    ")\n",
+    "\n",
+    "# Initialize the embedding service\n",
+    "embeddings_service = VertexAIEmbeddings(\n",
+    "    model_name=\"textembedding-gecko@latest\", project=PROJECT_ID\n",
+    ")\n",
+    "\n",
+    "# Initialize the engine\n",
+    "mysql_engine = MySQLEngine.from_instance(\n",
+    "    project_id=PROJECT_ID,\n",
+    "    instance=INSTANCE_NAME,\n",
+    "    region=REGION,\n",
+    "    database=DATABASE_NAME,\n",
+    "    user=\"root\",\n",
+    "    password=PASSWORD,\n",
+    ")\n",
+    "\n",
+    "# Initialize the Vector Store\n",
+    "vector_table_name = \"vector_netflix_titles\"\n",
+    "vector_store = MySQLVectorStore(\n",
+    "    engine=mysql_engine,\n",
+    "    embedding_service=embeddings_service,\n",
+    "    table_name=vector_table_name,\n",
+    "    metadata_columns=[\n",
+    "        \"show_id\",\n",
+    "        \"type\",\n",
+    "        \"country\",\n",
+    "        \"date_added\",\n",
+    "        \"release_year\",\n",
+    "        \"duration\",\n",
+    "        \"listed_in\",\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "# Initialize the PostgresChatMessageHistory\n",
+    "chat_history = MySQLChatMessageHistory(\n",
+    "    mysql_engine,\n",
+    "    session_id=\"my-test-session\",\n",
+    "    table_name=\"message_store\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Ytlz9D3LmcU7"
+   },
+   "source": [
+    "Let's create a prompt for the LLM. Here we can add instructions specific to our application, such as \"Don't make things up\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "id": "LoAHNdrWmW9W"
+   },
+   "outputs": [],
+   "source": [
+    "# Prepare some prompt templates for the ConversationalRetrievalChain\n",
+    "prompt = PromptTemplate(\n",
+    "    template=\"\"\"Use all the information from the context and the conversation history to answer new question. If you see the answer in previous conversation history or the context. \\\n",
+    "Answer it with clarifying the source information. If you don't see it in the context or the chat history, just say you \\\n",
+    "didn't find the answer in the given data. Don't make things up.\n",
+    "\n",
+    "Previous conversation history from the questioner. \"Human\" was the user who's asking the new question. \"Assistant\" was you as the assistant:\n",
+    "```{chat_history}\n",
+    "```\n",
+    "\n",
+    "Vector search result of the new question:\n",
+    "```{context}\n",
+    "```\n",
+    "\n",
+    "New Question:\n",
+    "```{question}```\n",
+    "\n",
+    "Answer:\"\"\",\n",
+    "    input_variables=[\"context\", \"question\", \"chat_history\"],\n",
+    ")\n",
+    "condense_question_prompt_passthrough = PromptTemplate(\n",
+    "    template=\"\"\"Repeat the following question:\n",
+    "{question}\n",
+    "\"\"\",\n",
+    "    input_variables=[\"question\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rsGe-bW5m0H1"
+   },
+   "source": [
+    "Now let's use our vector store as a retreiver. Retreiver's in Langchain allow us to literally \"retrieve\" documents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "id": "1nI0xkJamvXt"
+   },
+   "outputs": [],
+   "source": [
+    "# Initialize retriever, llm and memory for the chain\n",
+    "retriever = vector_store.as_retriever(\n",
+    "    search_type=\"mmr\", search_kwargs={\"k\": 5, \"lambda_mult\": 0.8}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3maZ8SLlneYJ"
+   },
+   "source": [
+    "Now let's initialize our LLM, in this case we are using Vertex AI's \"gemini-pro\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "id": "VBWhg-ihnnxF"
+   },
+   "outputs": [],
+   "source": [
+    "llm = VertexAI(model_name=\"gemini-pro\", project=PROJECT_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hN8mpXdtnocg"
+   },
+   "source": [
+    "We clear our chat history, so that our application starts without any prior context to other conversations we have had with the application."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "id": "1UkPcEpJno5Y"
+   },
+   "outputs": [],
+   "source": [
+    "chat_history.clear()\n",
+    "\n",
+    "memory = ConversationSummaryBufferMemory(\n",
+    "    llm=llm,\n",
+    "    chat_memory=chat_history,\n",
+    "    output_key=\"answer\",\n",
+    "    memory_key=\"chat_history\",\n",
+    "    return_messages=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BDAT2koSn8Mz"
+   },
+   "source": [
+    "Now let's create a conversational retrieval chain. This will allow the LLM to use chat history in it's responses, meaning we can ask it follow up questions to our questions instead of having to start from scratch after each inquiry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "7Fu8fKdEn8h8",
+    "outputId": "593133a2-424a-4551-f637-1e3391405a2b"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "/usr/local/lib/python3.10/dist-packages/langchain_core/_api/deprecation.py:117: LangChainDeprecationWarning: The function `__call__` was deprecated in LangChain 0.1.0 and will be removed in 0.2.0. Use invoke instead.\n",
+      "  warn_deprecated(\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Question: What movie was Brad Pitt in?\n",
+      "Answer: Brad Pitt was in the following movies: Inglourious Basterds, By the Sea, Killing Them Softly, Babel, War Machine\n",
+      "\n",
+      "Question: How about Johnny Depp?\n",
+      "Answer: Johnny Depp was in the following movies: The Rum Diary, Charlie and the Chocolate Factory, The Tourist, The Imaginarium of Doctor Parnassus, What's Eating Gilbert Grape. (Source: vector search result)\n",
+      "\n",
+      "Question: Are there movies about animals?\n",
+      "Answer: Yes, from the vector search result, there are the following movies that feature animals:\n",
+      "\n",
+      "- Animals on the Loose: A You vs. Wild Movie\n",
+      "- Rango\n",
+      "- Kung Fu Panda: Secrets of the Scroll\n",
+      "- Balto\n",
+      "- Cats & Dogs: The Revenge of Kitty Galore\n",
+      "\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "[HumanMessage(content='What movie was Brad Pitt in?'),\n",
+       " AIMessage(content='Brad Pitt was in the following movies: Inglourious Basterds, By the Sea, Killing Them Softly, Babel, War Machine'),\n",
+       " HumanMessage(content='How about Johnny Depp?'),\n",
+       " AIMessage(content=\"Johnny Depp was in the following movies: The Rum Diary, Charlie and the Chocolate Factory, The Tourist, The Imaginarium of Doctor Parnassus, What's Eating Gilbert Grape. (Source: vector search result)\"),\n",
+       " HumanMessage(content='Are there movies about animals?'),\n",
+       " AIMessage(content='Yes, from the vector search result, there are the following movies that feature animals:\\n\\n- Animals on the Loose: A You vs. Wild Movie\\n- Rango\\n- Kung Fu Panda: Secrets of the Scroll\\n- Balto\\n- Cats & Dogs: The Revenge of Kitty Galore')]"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 20
+    }
+   ],
+   "source": [
+    "# create the ConversationalRetrievalChain\n",
+    "rag_chain = ConversationalRetrievalChain.from_llm(\n",
+    "    llm=llm,\n",
+    "    retriever=retriever,\n",
+    "    verbose=False,\n",
+    "    memory=memory,\n",
+    "    condense_question_prompt=condense_question_prompt_passthrough,\n",
+    "    combine_docs_chain_kwargs={\"prompt\": prompt},\n",
+    ")\n",
+    "\n",
+    "# ask some questions\n",
+    "q = \"What movie was Brad Pitt in?\"\n",
+    "ans = rag_chain({\"question\": q, \"chat_history\": chat_history})[\"answer\"]\n",
+    "print(f\"Question: {q}\\nAnswer: {ans}\\n\")\n",
+    "\n",
+    "q = \"How about Johnny Depp?\"\n",
+    "ans = rag_chain({\"question\": q, \"chat_history\": chat_history})[\"answer\"]\n",
+    "print(f\"Question: {q}\\nAnswer: {ans}\\n\")\n",
+    "\n",
+    "q = \"Are there movies about animals?\"\n",
+    "ans = rag_chain({\"question\": q, \"chat_history\": chat_history})[\"answer\"]\n",
+    "print(f\"Question: {q}\\nAnswer: {ans}\\n\")\n",
+    "\n",
+    "# browser the chat history\n",
+    "chat_history.messages"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/samples/langchain_quick_start.ipynb
+++ b/samples/langchain_quick_start.ipynb
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "id": "a168rJE1xDHO"
    },
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "id": "qjFuhRhVxlWP",
@@ -398,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "id": "zrwTsWHMkQ_v"
    },
@@ -427,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "id": "2SdFJT6Vece1"
    },
@@ -455,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -519,7 +519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "id": "e_rmjywG47pv"
    },
@@ -561,7 +561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "id": "Wo4-7EYCIFF9"
    },
@@ -667,12 +667,12 @@
     "id": "dxqIPQtjDquk"
    },
    "source": [
-    "Next we will add chat history (called [“memory” in the context of LangChain](https://python.langchain.com/docs/modules/memory/)) to our application so the LLM can retain context and information across multiple interactions, leading to more coherent and sophisticated conversations or text generation. We can use Cloud SQL for PostgreSQL as “memory” storage in our application so that the LLM can use context from prior conversations to better answer the user’s prompts. First let's initialize Cloud SQL for MySQL as memory storage."
+    "Next we will add chat history (called [“memory” in the context of LangChain](https://python.langchain.com/docs/modules/memory/)) to our application so the LLM can retain context and information across multiple interactions, leading to more coherent and sophisticated conversations or text generation. We can use Cloud SQL for MySQL as “memory” storage in our application so that the LLM can use context from prior conversations to better answer the user’s prompts. First let's initialize Cloud SQL for MySQL as memory storage."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "id": "vyYQILyoEAqg"
    },
@@ -702,7 +702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -754,7 +754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "id": "9ukjOO-sNQ8_"
    },
@@ -802,7 +802,7 @@
     "    ],\n",
     ")\n",
     "\n",
-    "# Initialize the PostgresChatMessageHistory\n",
+    "# Initialize the MySQLChatMessageHistory\n",
     "chat_history = MySQLChatMessageHistory(\n",
     "    mysql_engine,\n",
     "    session_id=\"my-test-session\",\n",
@@ -821,7 +821,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "id": "LoAHNdrWmW9W"
    },
@@ -866,7 +866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "id": "1nI0xkJamvXt"
    },
@@ -889,7 +889,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "id": "VBWhg-ihnnxF"
    },
@@ -909,7 +909,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "id": "1UkPcEpJno5Y"
    },
@@ -937,7 +937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"

--- a/samples/langchain_quick_start.ipynb
+++ b/samples/langchain_quick_start.ipynb
@@ -279,7 +279,9 @@
     "\n",
     "A database named `langchain_db` will be created and used for the rest of the quickstart.\n",
     "\n",
-    "**Note:** MySQL vector support is only available on MySQL instances with version >= 8.0.36\n",
+    "**Note:** MySQL vector support is only available on MySQL instances with version **>= 8.0.36**.\n",
+    "\n",
+    "> For existing instances, you may need to perform a [self-service maintenance update](MYSQL_8_0_36.R20240401.03_00) to update your maintenance version to **MYSQL_8_0_36.R20240401.03_00** or greater. Once updated, [configure your database flags](https://cloud.google.com/sql/docs/mysql/flags) to have thew new **cloudsql_vector** flag to \"On\".\n",
     "\n",
     "> ⏳ - Creating a Cloud SQL instance may take a few minutes."
    ]
@@ -314,7 +316,7 @@
     "  print(\"Creating new Cloud SQL instance...\")\n",
     "  !gcloud sql instances create {INSTANCE_NAME} --database-version=MYSQL_8_0_36 \\\n",
     "    --region={REGION} --cpu=1 --memory=4GB --root-password={PASSWORD} \\\n",
-    "    --database-flags=cloudsql_iam_authentication=On\n",
+    "    --database-flags=cloudsql_iam_authentication=On,cloudsql_vector=On\n",
     "\n",
     "databases = !gcloud sql databases list --instance={INSTANCE_NAME} --format=\"value(name)\"\n",
     "if DATABASE_NAME not in databases:\n",


### PR DESCRIPTION
Full quickstart showcasing the combined usage of MySQLVectorStore, MySQLLoader (doc loader) and MySQLChatMessageHistory in a RAG workflow using movie title dataset.

Rendered notebook can be found here: https://github.com/googleapis/langchain-google-cloud-sql-mysql-python/blob/mysql-quickstart/samples/langchain_quick_start.ipynb