### PR TITLE
fix: use lazy refresh for Cloud SQL Connector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "langchain-community>=0.0.18, <1.0.0",
     "numpy>=1.24.4, <2.0.0",
     "SQLAlchemy>=2.0.7, <3.0.0",
-    "cloud-sql-python-connector[pymysql]>=1.7.0, <2.0.0"
+    "cloud-sql-python-connector[pymysql]>=1.10.0, <2.0.0"
 ]
 
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ langchain-community==0.2.0
 numpy===1.24.4; python_version <= "3.8"
 numpy==1.26.4; python_version > "3.8"
 SQLAlchemy==2.0.30
-cloud-sql-python-connector[pymysql]==1.9.2
+cloud-sql-python-connector[pymysql]==1.10.0
 

--- a/src/langchain_google_cloud_sql_mysql/engine.py
+++ b/src/langchain_google_cloud_sql_mysql/engine.py
@@ -21,7 +21,7 @@ import google.auth
 import google.auth.transport.requests
 import requests
 import sqlalchemy
-from google.cloud.sql.connector import Connector
+from google.cloud.sql.connector import Connector, RefreshStrategy
 
 from .version import __version__
 
@@ -193,7 +193,9 @@ class MySQLEngine:
             enable_iam_auth = True
 
         if cls._connector is None:
-            cls._connector = Connector(user_agent=USER_AGENT)
+            cls._connector = Connector(
+                user_agent=USER_AGENT, refresh_strategy=RefreshStrategy.LAZY
+            )
 
         # anonymous function to be used for SQLAlchemy 'creator' argument
         def getconn() -> pymysql.Connection:


### PR DESCRIPTION
The Cloud SQL Python Connector just released a new version `v1.10.0`
that supports setting the `refresh_strategy` argument of the connector.

Setting the refresh strategy to lazy refresh is recommended for
serverless environments. As the default refresh strategy is to
have background refreshes occur to get the instance metadata and a fresh
certificate to use for the SSL/TLS connection.

However, these background refreshes can be throttled when serverless
environments scale to zero (Cloud Functions, Cloud Run etc.).

This PR will fix the ambiguous errors that are a result of the CPU being
throttled for the Cloud SQL Connector.
