### PR TITLE
docs: update README to reflect supported maintenance version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ steps:
 .. _Setup Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Supported Cloud SQL Maintenance Versions
-~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This LangChain integration is only supported for Cloud SQL maintenance versions between **MYSQL_8_0_36.R20240401.03_00** and **MYSQL_8_0_36.R20241208.01_00**
 

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,11 @@ steps:
 .. _Enable the Google Cloud SQL Admin API.: https://console.cloud.google.com/flows/enableapi?apiid=sqladmin.googleapis.com
 .. _Setup Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
+Supported Cloud SQL Maintenance Versions
+~~~~~~~~~~~~
+
+This LangChain integration is only supported for Cloud SQL maintenance versions between **MYSQL_8_0_36.R20240401.03_00** and **MYSQL_8_0_36.R20241208.01_00**
+
 Installation
 ~~~~~~~~~~~~
 

--- a/docs/vector_store.ipynb
+++ b/docs/vector_store.ipynb
@@ -29,7 +29,9 @@
     "\n",
     " * [Create a Google Cloud Project](https://developers.google.com/workspace/guides/create-project)\n",
     " * [Enable the Cloud SQL Admin API.](https://console.cloud.google.com/flows/enableapi?apiid=sqladmin.googleapis.com)\n",
-    " * [Create a Cloud SQL instance.](https://cloud.google.com/sql/docs/mysql/connect-instance-auth-proxy#create-instance) (version must be >= **8.0.36** with **cloudsql_vector** database flag configured to \"On\")\n",
+    " * [Create a Cloud SQL instance.](https://cloud.google.com/sql/docs/mysql/connect-instance-auth-proxy#create-instance) \n",
+    "     * Database version must be >= **8.0.36** with **cloudsql_vector** database flag configured to \"On\"\n",
+    "     * Cloud SQL maintenance version must be between **MYSQL_8_0_36.R20240401.03_00** and **MYSQL_8_0_36.R20241208.01_00**\n",
     " * [Create a Cloud SQL database.](https://cloud.google.com/sql/docs/mysql/create-manage-databases)\n",
     " * [Add a User to the database.](https://cloud.google.com/sql/docs/mysql/create-manage-users)"
    ]
@@ -379,16 +381,16 @@
    "cell_type": "code",
    "execution_count": 17,
    "metadata": {
-    "id": "fpqeZgUeLL54",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "fpqeZgUeLL54",
     "outputId": "f674a3af-452c-4d58-bb62-cbf514a9e1e3"
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Pineapple\n"
      ]
@@ -415,16 +417,16 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "N-NC5jgGLL55",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "N-NC5jgGLL55",
     "outputId": "69a1f9de-a830-450d-8a5e-118b36815a46"
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[Document(page_content='Pineapple', metadata={'len': 9}), Document(page_content='Banana', metadata={'len': 6})]\n"
      ]
@@ -490,12 +492,12 @@
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Advanced Usage"
-   ],
    "metadata": {
     "id": "K8XAZZTDqwIp"
-   }
+   },
+   "source": [
+    "## Advanced Usage"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -560,16 +562,16 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "Sqfgk6EOLL5-",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "Sqfgk6EOLL5-",
     "outputId": "a10c74e2-fe48-4cf9-ba2f-85aecb2490d0"
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[Document(page_content='Pineapple', metadata={'len': 9}), Document(page_content='Banana', metadata={'len': 6}), Document(page_content='Apples and oranges', metadata={'len': 18}), Document(page_content='Cars and airplanes', metadata={'len': 18})]\n"
      ]
@@ -593,6 +595,7 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Example Workflow\n",
     "\n",
@@ -601,11 +604,13 @@
     "Load the document, split it into chunks, embed each chunk and load it into the vector store.\n",
     "\n",
     "You can download the `state_of_the_union.txt` file [here](https://github.com/langchain-ai/langchain/blob/master/docs/docs/modules/state_of_the_union.txt).\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from langchain_community.document_loaders import TextLoader\n",
     "from langchain_google_vertexai import VertexAIEmbeddings\n",
@@ -623,13 +628,13 @@
     "embeddings = VertexAIEmbeddings(\n",
     "    model_name=\"textembedding-gecko@003\", project=PROJECT_ID\n",
     ")"
-   ],
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import uuid\n",
     "\n",
@@ -653,30 +658,22 @@
     "\n",
     "ids = [str(uuid.uuid4()) for _ in documents]\n",
     "db = MySQLVectorStore.from_documents(documents, embeddings, engine, table_name, ids)"
-   ],
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "query = \"What did the president say about Ketanji Brown Jackson\"\n",
-    "docs = db.similarity_search(query)\n",
-    "print(docs[0].page_content)"
-   ],
+   "execution_count": null,
    "metadata": {
-    "id": "EUp4DpizYy2N",
-    "outputId": "18d0c336-6fea-4bba-9ba4-6fcc60fb5194",
     "colab": {
      "base_uri": "https://localhost:8080/"
-    }
+    },
+    "id": "EUp4DpizYy2N",
+    "outputId": "18d0c336-6fea-4bba-9ba4-6fcc60fb5194"
    },
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Tonight. I call on the Senate to: Pass the Freedom to Vote Act. Pass the John Lewis Voting Rights Act. And while you’re at it, pass the Disclose Act so Americans can know who is funding our elections. \n",
       "\n",
@@ -687,6 +684,11 @@
       "And I did that 4 days ago, when I nominated Circuit Court of Appeals Judge Ketanji Brown Jackson. One of our nation’s top legal minds, who will continue Justice Breyer’s legacy of excellence.\n"
      ]
     }
+   ],
+   "source": [
+    "query = \"What did the president say about Ketanji Brown Jackson\"\n",
+    "docs = db.similarity_search(query)\n",
+    "print(docs[0].page_content)"
    ]
   }
  ],

--- a/samples/langchain_quick_start.ipynb
+++ b/samples/langchain_quick_start.ipynb
@@ -271,9 +271,9 @@
     "\n",
     "A database named `langchain_db` will be created and used for the rest of the quickstart.\n",
     "\n",
-    "**Note:** MySQL vector support is only available on MySQL instances with version **>= 8.0.36**.\n",
+    "**Note:** MySQL vector support is only available on MySQL instances with version **>= 8.0.36**. This LangChain integration is only supported for maintenance versions between **MYSQL_8_0_36.R20240401.03_00** and **MYSQL_8_0_36.R20241208.01_00**\n",
     "\n",
-    "> For existing instances, you may need to perform a [self-service maintenance update](https://cloud.google.com/sql/docs/mysql/self-service-maintenance) to update your maintenance version to **MYSQL_8_0_36.R20240401.03_00** or greater. Once updated, [configure your database flags](https://cloud.google.com/sql/docs/mysql/flags) to have thew new **cloudsql_vector** flag to \"On\".\n",
+    "> On the instance, [configure your database flags](https://cloud.google.com/sql/docs/mysql/flags) to have thew new **cloudsql_vector** flag to \"On\".\n",
     "\n",
     "> ⏳ - Creating a Cloud SQL instance may take a few minutes."
    ]


### PR DESCRIPTION
MySQL vector syntax has changed in the latest maintenance version (see https://cloud.google.com/sql/docs/mysql/work-with-vectors). We are yet to update the integration to use this new syntax, so need to call out the supported versions while we work on a new version of the integration. The updated syntax includes changing the ANN search function name, parameters, and where it can appear in a query. Additionally, create/drop/alter vector index syntax has changed. There are also some new restrictions, ie a table must have 1000 rows before creating an index.
